### PR TITLE
feat(nx-typeorm): generate db-specific datasource connection options for bootstrap

### DIFF
--- a/packages/typeorm-e2e/src/nx-typeorm.spec.ts
+++ b/packages/typeorm-e2e/src/nx-typeorm.spec.ts
@@ -105,7 +105,7 @@ export class AppModule {}
       `yarn nx g @anarchitects/nx-typeorm:bootstrap --project=${nestProjectName} --skipInstall --no-interactive`
     );
     runNx(
-      `yarn nx g @anarchitects/nx-typeorm:bootstrap --project=${plainProjectName} --skipInstall --no-interactive`
+      `yarn nx g @anarchitects/nx-typeorm:bootstrap --project=${plainProjectName} --db=sqlite --skipInstall --no-interactive`
     );
 
     const nestModule = readFileSync(
@@ -118,6 +118,38 @@ export class AppModule {}
     expect(
       existsSync(join(workspaceRoot, plainProjectRoot, 'src/data-source.ts'))
     ).toBe(true);
+    expect(
+      existsSync(
+        join(
+          workspaceRoot,
+          plainProjectRoot,
+          'tools/typeorm/connection-options.ts'
+        )
+      )
+    ).toBe(true);
+    expect(
+      existsSync(
+        join(
+          workspaceRoot,
+          plainProjectRoot,
+          'tools/typeorm/datasource.migrations.ts'
+        )
+      )
+    ).toBe(true);
+
+    const plainConnectionOptions = readFileSync(
+      join(workspaceRoot, plainProjectRoot, 'tools/typeorm/connection-options.ts'),
+      'utf-8'
+    );
+    expect(plainConnectionOptions).toContain("type: 'sqlite'");
+    expect(plainConnectionOptions).toContain('TYPEORM_DATABASE');
+
+    const plainEnvExample = readFileSync(
+      join(workspaceRoot, plainProjectRoot, 'env.example'),
+      'utf-8'
+    );
+    expect(plainEnvExample).toContain('TYPEORM_DATABASE=');
+    expect(plainEnvExample).toContain('Mixed mode is rejected.');
     expect(
       readFileSync(
         join(workspaceRoot, plainProjectRoot, 'src/main.ts'),

--- a/packages/typeorm/README.md
+++ b/packages/typeorm/README.md
@@ -47,7 +47,11 @@ For applications:
 
 - generates runtime datasource in `src/data-source.ts`.
 - generates compatibility re-export `src/typeorm.datasource.ts`.
-- generates TypeORM CLI datasource/seeds under `tools/typeorm`.
+- generates shared connection helper `tools/typeorm/connection-options.ts`.
+- generates TypeORM CLI migration datasource
+  `tools/typeorm/datasource.migrations.ts` and seeds under `tools/typeorm`.
+- preserves an existing `tools/typeorm/datasource.migrations.ts` file.
+- generates a DB-specific `env.example` with URL/discrete modes.
 - patches `app.module.ts` only when the app has a Nest module file.
 
 For libraries:
@@ -63,6 +67,18 @@ Additional bootstrap dependencies are installed during bootstrap:
 `ts-node`, `typeorm-ts-node-commonjs`, `typeorm-ts-node-esm`,
 DB driver package for selected `--db`, and `@nestjs/typeorm` only for Nest
 applications.
+
+Supported `--db` values: `postgres`, `postgresql` (normalized to `postgres`),
+`mysql`, `mariadb`, `sqlite`, `better-sqlite3`, `mssql`.
+
+Generated app datasources support two connection modes:
+
+- `DATABASE_URL`
+- discrete `TYPEORM_*` variables
+
+The generated helper rejects mixed mode (setting `DATABASE_URL` together with
+`TYPEORM_*` connection variables) and throws clear validation errors when
+required variables are missing.
 
 ## Inferred Targets
 

--- a/packages/typeorm/src/generators/bootstrap/files/app/env.example__tmpl__
+++ b/packages/typeorm/src/generators/bootstrap/files/app/env.example__tmpl__
@@ -1,1 +1,55 @@
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/<%= appDatabase %>
+# Choose one configuration mode:
+# 1) DATABASE_URL
+# 2) TYPEORM_* discrete variables
+# Mixed mode is rejected.
+
+# Mode 1: DATABASE_URL
+<% if (database === 'postgres') { %>DATABASE_URL=postgresql://postgres:postgres@localhost:5432/<%= appDatabase %>
+<% } %><% if (database === 'mysql' || database === 'mariadb') { %>DATABASE_URL=<%= database %>://root:root@localhost:3306/<%= appDatabase %>
+<% } %><% if (database === 'mssql') { %>DATABASE_URL=sqlserver://sa:StrongPassword!123@localhost:1433;database=<%= appDatabase %>
+<% } %><% if (database === 'sqlite' || database === 'better-sqlite3') { %>DATABASE_URL=./tmp/<%= appDatabase %>.sqlite
+<% } %>
+
+# Mode 2: TYPEORM_* variables
+<% if (database === 'postgres') { %>TYPEORM_HOST=localhost
+TYPEORM_PORT=5432
+TYPEORM_USERNAME=postgres
+TYPEORM_PASSWORD=postgres
+TYPEORM_DATABASE=<%= appDatabase %>
+TYPEORM_SCHEMA=public
+TYPEORM_SSL=false
+# TYPEORM_SSL can also be a JSON object:
+# TYPEORM_SSL={"rejectUnauthorized":false}
+TYPEORM_APPLICATION_NAME=<%= appDatabase %>-service
+TYPEORM_CONNECT_TIMEOUT_MS=5000
+<% } %><% if (database === 'mysql' || database === 'mariadb') { %>TYPEORM_HOST=localhost
+TYPEORM_PORT=3306
+TYPEORM_USERNAME=root
+TYPEORM_PASSWORD=root
+TYPEORM_DATABASE=<%= appDatabase %>
+TYPEORM_SSL=false
+TYPEORM_SOCKET_PATH=
+TYPEORM_CHARSET=utf8mb4
+TYPEORM_TIMEZONE=Z
+TYPEORM_CONNECT_TIMEOUT=10000
+<% } %><% if (database === 'mssql') { %>TYPEORM_HOST=localhost
+TYPEORM_PORT=1433
+TYPEORM_USERNAME=sa
+TYPEORM_PASSWORD=StrongPassword!123
+TYPEORM_DATABASE=<%= appDatabase %>
+TYPEORM_DOMAIN=
+TYPEORM_CONNECTION_TIMEOUT=15000
+TYPEORM_REQUEST_TIMEOUT=15000
+TYPEORM_ENCRYPT=false
+TYPEORM_TRUST_SERVER_CERTIFICATE=true
+TYPEORM_INSTANCE_NAME=
+<% } %><% if (database === 'sqlite') { %>TYPEORM_DATABASE=./tmp/<%= appDatabase %>.sqlite
+TYPEORM_BUSY_TIMEOUT=5000
+TYPEORM_ENABLE_WAL=true
+<% } %><% if (database === 'better-sqlite3') { %>TYPEORM_DATABASE=./tmp/<%= appDatabase %>.sqlite
+TYPEORM_ENABLE_WAL=true
+TYPEORM_TIMEOUT=5000
+TYPEORM_READONLY=false
+TYPEORM_FILE_MUST_EXIST=false
+TYPEORM_STATEMENT_CACHE_SIZE=100
+<% } %>

--- a/packages/typeorm/src/generators/bootstrap/files/app/src/data-source.ts__tmpl__
+++ b/packages/typeorm/src/generators/bootstrap/files/app/src/data-source.ts__tmpl__
@@ -1,15 +1,6 @@
 import { DataSource } from 'typeorm';
+import { createRuntimeDataSourceOptions } from '../tools/typeorm/connection-options';
 
 export function makeRuntimeDataSource(): DataSource {
-  const url = process.env.DATABASE_URL;
-  if (!url) {
-    throw new Error('Missing DATABASE_URL');
-  }
-
-  return new DataSource({
-    type: '<%= database %>',
-    url,
-    synchronize: false,
-    logging: false,
-  });
+  return new DataSource(createRuntimeDataSourceOptions());
 }

--- a/packages/typeorm/src/generators/bootstrap/files/app/tools/typeorm/connection-options.ts__tmpl__
+++ b/packages/typeorm/src/generators/bootstrap/files/app/tools/typeorm/connection-options.ts__tmpl__
@@ -1,0 +1,292 @@
+import type { DataSourceOptions } from 'typeorm';
+
+type ConnectionMode = 'url' | 'fields';
+
+const DATABASE_URL_KEY = 'DATABASE_URL';
+const URL_OR_FIELDS_ERROR =
+  'Invalid TypeORM connection configuration. Provide either DATABASE_URL or TYPEORM_* variables, not both.';
+const TRUE_VALUES = new Set(['1', 'true', 'yes', 'on']);
+const FALSE_VALUES = new Set(['0', 'false', 'no', 'off']);
+<% if (database === 'postgres') { %>const DISCRETE_ENV_KEYS = [
+  'TYPEORM_HOST',
+  'TYPEORM_PORT',
+  'TYPEORM_USERNAME',
+  'TYPEORM_PASSWORD',
+  'TYPEORM_DATABASE',
+  'TYPEORM_SCHEMA',
+  'TYPEORM_SSL',
+  'TYPEORM_APPLICATION_NAME',
+  'TYPEORM_CONNECT_TIMEOUT_MS',
+] as const;
+
+type DatabaseConnectionOptions = Extract<DataSourceOptions, { type: 'postgres' }>;
+<% } %><% if (database === 'mysql' || database === 'mariadb') { %>const DISCRETE_ENV_KEYS = [
+  'TYPEORM_HOST',
+  'TYPEORM_PORT',
+  'TYPEORM_USERNAME',
+  'TYPEORM_PASSWORD',
+  'TYPEORM_DATABASE',
+  'TYPEORM_SSL',
+  'TYPEORM_SOCKET_PATH',
+  'TYPEORM_CHARSET',
+  'TYPEORM_TIMEZONE',
+  'TYPEORM_CONNECT_TIMEOUT',
+] as const;
+
+type DatabaseConnectionOptions = Extract<DataSourceOptions, { type: '<%= database %>' }>;
+<% } %><% if (database === 'mssql') { %>const DISCRETE_ENV_KEYS = [
+  'TYPEORM_HOST',
+  'TYPEORM_PORT',
+  'TYPEORM_USERNAME',
+  'TYPEORM_PASSWORD',
+  'TYPEORM_DATABASE',
+  'TYPEORM_DOMAIN',
+  'TYPEORM_CONNECTION_TIMEOUT',
+  'TYPEORM_REQUEST_TIMEOUT',
+  'TYPEORM_ENCRYPT',
+  'TYPEORM_TRUST_SERVER_CERTIFICATE',
+  'TYPEORM_INSTANCE_NAME',
+] as const;
+
+type DatabaseConnectionOptions = Extract<DataSourceOptions, { type: 'mssql' }>;
+<% } %><% if (database === 'sqlite') { %>const DISCRETE_ENV_KEYS = [
+  'TYPEORM_DATABASE',
+  'TYPEORM_BUSY_TIMEOUT',
+  'TYPEORM_ENABLE_WAL',
+] as const;
+
+type DatabaseConnectionOptions = Extract<DataSourceOptions, { type: 'sqlite' }>;
+<% } %><% if (database === 'better-sqlite3') { %>const DISCRETE_ENV_KEYS = [
+  'TYPEORM_DATABASE',
+  'TYPEORM_ENABLE_WAL',
+  'TYPEORM_TIMEOUT',
+  'TYPEORM_READONLY',
+  'TYPEORM_FILE_MUST_EXIST',
+  'TYPEORM_STATEMENT_CACHE_SIZE',
+] as const;
+
+type DatabaseConnectionOptions = Extract<DataSourceOptions, { type: 'better-sqlite3' }>;
+<% } %>
+
+export function createRuntimeDataSourceOptions(): DataSourceOptions {
+  return {
+    ...createConnectionOptions(),
+    synchronize: false,
+    logging: false,
+  };
+}
+
+export function createMigrationDataSourceOptions(): DataSourceOptions {
+  return {
+    ...createConnectionOptions(),
+    entities: [],
+    migrations: ['dist/tools/typeorm/migrations/*.js'],
+    synchronize: false,
+    logging: false,
+  };
+}
+
+function createConnectionOptions(): DatabaseConnectionOptions {
+  return resolveConnectionMode() === 'url'
+    ? createOptionsFromUrl()
+    : createOptionsFromFields();
+}
+
+function resolveConnectionMode(): ConnectionMode {
+  const hasDatabaseUrl = optionalEnv(DATABASE_URL_KEY) !== undefined;
+  const hasDiscreteVariables = DISCRETE_ENV_KEYS.some(
+    (key) => optionalEnv(key) !== undefined
+  );
+
+  if (hasDatabaseUrl && hasDiscreteVariables) {
+    throw new Error(URL_OR_FIELDS_ERROR);
+  }
+
+  return hasDatabaseUrl ? 'url' : 'fields';
+}
+
+function requiredEnv(name: string): string {
+  const value = optionalEnv(name);
+  if (!value) {
+    throw new Error(`Missing required environment variable "${name}".`);
+  }
+  return value;
+}
+
+function optionalEnv(name: string): string | undefined {
+  const value = process.env[name];
+  if (!value) {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parseBooleanEnv(name: string): boolean | undefined {
+  const value = optionalEnv(name);
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const normalized = value.toLowerCase();
+  if (TRUE_VALUES.has(normalized)) {
+    return true;
+  }
+
+  if (FALSE_VALUES.has(normalized)) {
+    return false;
+  }
+
+  throw new Error(
+    `Environment variable "${name}" must be a boolean value (true/false/1/0/yes/no/on/off).`
+  );
+}
+
+function parseIntegerEnv(name: string): number | undefined {
+  const value = optionalEnv(name);
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!/^-?\d+$/.test(value)) {
+    throw new Error(`Environment variable "${name}" must be an integer.`);
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error(`Environment variable "${name}" must be an integer.`);
+  }
+  return parsed;
+}
+
+function parseSslEnv(name: string): boolean | Record<string, unknown> | undefined {
+  const value = optionalEnv(name);
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const normalized = value.toLowerCase();
+  if (TRUE_VALUES.has(normalized)) {
+    return true;
+  }
+  if (FALSE_VALUES.has(normalized)) {
+    return false;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Ignore and throw below with context.
+  }
+
+  throw new Error(
+    `Environment variable "${name}" must be a boolean or a JSON object.`
+  );
+}
+
+<% if (database === 'postgres') { %>function createOptionsFromUrl(): DatabaseConnectionOptions {
+  return {
+    type: 'postgres',
+    url: requiredEnv(DATABASE_URL_KEY),
+  };
+}
+
+function createOptionsFromFields(): DatabaseConnectionOptions {
+  return {
+    type: 'postgres',
+    host: requiredEnv('TYPEORM_HOST'),
+    port: parseIntegerEnv('TYPEORM_PORT') ?? 5432,
+    username: requiredEnv('TYPEORM_USERNAME'),
+    password: requiredEnv('TYPEORM_PASSWORD'),
+    database: requiredEnv('TYPEORM_DATABASE'),
+    schema: optionalEnv('TYPEORM_SCHEMA'),
+    ssl: parseSslEnv('TYPEORM_SSL'),
+    applicationName: optionalEnv('TYPEORM_APPLICATION_NAME'),
+    connectTimeoutMS: parseIntegerEnv('TYPEORM_CONNECT_TIMEOUT_MS'),
+  };
+}
+<% } %><% if (database === 'mysql' || database === 'mariadb') { %>function createOptionsFromUrl(): DatabaseConnectionOptions {
+  return {
+    type: '<%= database %>',
+    url: requiredEnv(DATABASE_URL_KEY),
+  };
+}
+
+function createOptionsFromFields(): DatabaseConnectionOptions {
+  return {
+    type: '<%= database %>',
+    host: requiredEnv('TYPEORM_HOST'),
+    port: parseIntegerEnv('TYPEORM_PORT') ?? 3306,
+    username: requiredEnv('TYPEORM_USERNAME'),
+    password: requiredEnv('TYPEORM_PASSWORD'),
+    database: requiredEnv('TYPEORM_DATABASE'),
+    ssl: parseSslEnv('TYPEORM_SSL'),
+    socketPath: optionalEnv('TYPEORM_SOCKET_PATH'),
+    charset: optionalEnv('TYPEORM_CHARSET'),
+    timezone: optionalEnv('TYPEORM_TIMEZONE'),
+    connectTimeout: parseIntegerEnv('TYPEORM_CONNECT_TIMEOUT'),
+  };
+}
+<% } %><% if (database === 'mssql') { %>function createOptionsFromUrl(): DatabaseConnectionOptions {
+  return {
+    type: 'mssql',
+    url: requiredEnv(DATABASE_URL_KEY),
+  };
+}
+
+function createOptionsFromFields(): DatabaseConnectionOptions {
+  return {
+    type: 'mssql',
+    host: requiredEnv('TYPEORM_HOST'),
+    port: parseIntegerEnv('TYPEORM_PORT') ?? 1433,
+    username: requiredEnv('TYPEORM_USERNAME'),
+    password: requiredEnv('TYPEORM_PASSWORD'),
+    database: requiredEnv('TYPEORM_DATABASE'),
+    domain: optionalEnv('TYPEORM_DOMAIN'),
+    connectionTimeout: parseIntegerEnv('TYPEORM_CONNECTION_TIMEOUT'),
+    requestTimeout: parseIntegerEnv('TYPEORM_REQUEST_TIMEOUT'),
+    options: {
+      encrypt: parseBooleanEnv('TYPEORM_ENCRYPT'),
+      trustServerCertificate: parseBooleanEnv('TYPEORM_TRUST_SERVER_CERTIFICATE'),
+      instanceName: optionalEnv('TYPEORM_INSTANCE_NAME'),
+    },
+  };
+}
+<% } %><% if (database === 'sqlite') { %>function createOptionsFromUrl(): DatabaseConnectionOptions {
+  return {
+    type: 'sqlite',
+    database: requiredEnv(DATABASE_URL_KEY),
+  };
+}
+
+function createOptionsFromFields(): DatabaseConnectionOptions {
+  return {
+    type: 'sqlite',
+    database: requiredEnv('TYPEORM_DATABASE'),
+    busyTimeout: parseIntegerEnv('TYPEORM_BUSY_TIMEOUT'),
+    enableWAL: parseBooleanEnv('TYPEORM_ENABLE_WAL'),
+  };
+}
+<% } %><% if (database === 'better-sqlite3') { %>function createOptionsFromUrl(): DatabaseConnectionOptions {
+  return {
+    type: 'better-sqlite3',
+    database: requiredEnv(DATABASE_URL_KEY),
+  };
+}
+
+function createOptionsFromFields(): DatabaseConnectionOptions {
+  return {
+    type: 'better-sqlite3',
+    database: requiredEnv('TYPEORM_DATABASE'),
+    enableWAL: parseBooleanEnv('TYPEORM_ENABLE_WAL'),
+    timeout: parseIntegerEnv('TYPEORM_TIMEOUT'),
+    readonly: parseBooleanEnv('TYPEORM_READONLY'),
+    fileMustExist: parseBooleanEnv('TYPEORM_FILE_MUST_EXIST'),
+    statementCacheSize: parseIntegerEnv('TYPEORM_STATEMENT_CACHE_SIZE'),
+  };
+}
+<% } %>

--- a/packages/typeorm/src/generators/bootstrap/files/app/tools/typeorm/datasource.migrations.ts__tmpl__
+++ b/packages/typeorm/src/generators/bootstrap/files/app/tools/typeorm/datasource.migrations.ts__tmpl__
@@ -1,9 +1,4 @@
 import { DataSource } from 'typeorm';
+import { createMigrationDataSourceOptions } from './connection-options';
 
-export default new DataSource({
-  type: '<%= database %>',
-  url: process.env.DATABASE_URL,
-  entities: [],
-  migrations: ['dist/tools/typeorm/migrations/*.js'],
-  synchronize: false,
-});
+export default new DataSource(createMigrationDataSourceOptions());

--- a/packages/typeorm/src/generators/bootstrap/files/app/tools/typeorm/datasource.runtime.ts__tmpl__
+++ b/packages/typeorm/src/generators/bootstrap/files/app/tools/typeorm/datasource.runtime.ts__tmpl__
@@ -1,9 +1,0 @@
-import { DataSource } from 'typeorm';
-
-export default new DataSource({
-  type: '<%= database %>',
-  url: process.env.DATABASE_URL,
-  entities: [],
-  migrations: ['dist/tools/typeorm/migrations/*.js'],
-  synchronize: false,
-});

--- a/packages/typeorm/src/generators/bootstrap/generator.spec.ts
+++ b/packages/typeorm/src/generators/bootstrap/generator.spec.ts
@@ -54,9 +54,15 @@ export class AppModule {}
     expect(typeof task).toBe('function');
     expect(tree.exists('apps/api/src/data-source.ts')).toBe(true);
     expect(tree.exists('apps/api/src/typeorm.datasource.ts')).toBe(true);
+    expect(tree.exists('apps/api/tools/typeorm/connection-options.ts')).toBe(
+      true
+    );
     expect(tree.exists('apps/api/tools/typeorm/datasource.migrations.ts')).toBe(
       true
     );
+    expect(
+      tree.read('apps/api/tools/typeorm/datasource.migrations.ts', 'utf-8')
+    ).toContain('createMigrationDataSourceOptions');
     expect(tree.exists('apps/api/docker-compose.yml')).toBe(false);
 
     const moduleSource = tree.read('apps/api/src/app.module.ts', 'utf-8');
@@ -67,6 +73,29 @@ export class AppModule {}
     expect(moduleSource).toContain('from "./data-source"');
     expect(moduleSource).toContain('TypeOrmModule.forRootAsync');
     expect(moduleSource).toContain('makeRuntimeDataSource');
+
+    const runtimeDataSourceSource = tree.read('apps/api/src/data-source.ts', 'utf-8');
+    expect(runtimeDataSourceSource).toContain(
+      "from '../tools/typeorm/connection-options'"
+    );
+    expect(runtimeDataSourceSource).toContain('createRuntimeDataSourceOptions');
+
+    const migrationDataSourceSource = tree.read(
+      'apps/api/tools/typeorm/datasource.migrations.ts',
+      'utf-8'
+    );
+    expect(migrationDataSourceSource).toContain("from './connection-options'");
+    expect(migrationDataSourceSource).toContain(
+      'createMigrationDataSourceOptions'
+    );
+
+    const connectionOptionsSource = tree.read(
+      'apps/api/tools/typeorm/connection-options.ts',
+      'utf-8'
+    );
+    expect(connectionOptionsSource).toContain(
+      "migrations: ['dist/tools/typeorm/migrations/*.js']"
+    );
 
     const packageJson = readJson(tree, 'package.json');
     expect(packageJson.dependencies['typeorm']).toBe('^0.3.28');
@@ -102,6 +131,9 @@ export class AppModule {}
 
     expect(tree.exists('apps/worker/src/data-source.ts')).toBe(true);
     expect(tree.exists('apps/worker/src/typeorm.datasource.ts')).toBe(true);
+    expect(tree.exists('apps/worker/tools/typeorm/connection-options.ts')).toBe(
+      true
+    );
     expect(
       tree.exists('apps/worker/tools/typeorm/datasource.migrations.ts')
     ).toBe(true);
@@ -137,6 +169,125 @@ export class AppModule {}
     });
 
     expect(tree.exists('apps/api/docker-compose.yml')).toBe(true);
+  });
+
+  it('preserves existing migration datasource for applications', async () => {
+    addProjectConfiguration(tree, 'api', {
+      root: 'apps/api',
+      sourceRoot: 'apps/api/src',
+      projectType: 'application',
+      targets: {},
+    });
+
+    tree.write(
+      'apps/api/tools/typeorm/datasource.migrations.ts',
+      "export default 'custom';\n"
+    );
+
+    await bootstrapGenerator(tree, {
+      project: 'api',
+      skipInstall: true,
+    });
+    await bootstrapGenerator(tree, {
+      project: 'api',
+      skipInstall: true,
+    });
+
+    expect(
+      tree.read('apps/api/tools/typeorm/datasource.migrations.ts', 'utf-8')
+    ).toBe("export default 'custom';\n");
+  });
+
+  it.each([
+    {
+      db: 'postgres',
+      expectedType: "type: 'postgres'",
+      helperSnippet: 'connectTimeoutMS',
+      envSnippet: 'TYPEORM_CONNECT_TIMEOUT_MS=5000',
+    },
+    {
+      db: 'postgresql',
+      expectedType: "type: 'postgres'",
+      helperSnippet: 'applicationName',
+      envSnippet: 'TYPEORM_SCHEMA=public',
+    },
+    {
+      db: 'mysql',
+      expectedType: "type: 'mysql'",
+      helperSnippet: 'socketPath',
+      envSnippet: 'TYPEORM_SOCKET_PATH=',
+    },
+    {
+      db: 'mariadb',
+      expectedType: "type: 'mariadb'",
+      helperSnippet: 'charset',
+      envSnippet: 'TYPEORM_CHARSET=utf8mb4',
+    },
+    {
+      db: 'sqlite',
+      expectedType: "type: 'sqlite'",
+      helperSnippet: 'busyTimeout',
+      envSnippet: 'TYPEORM_BUSY_TIMEOUT=5000',
+    },
+    {
+      db: 'better-sqlite3',
+      expectedType: "type: 'better-sqlite3'",
+      helperSnippet: 'statementCacheSize',
+      envSnippet: 'TYPEORM_STATEMENT_CACHE_SIZE=100',
+    },
+    {
+      db: 'mssql',
+      expectedType: "type: 'mssql'",
+      helperSnippet: 'trustServerCertificate',
+      envSnippet: 'TYPEORM_TRUST_SERVER_CERTIFICATE=true',
+    },
+  ])(
+    'generates database-specific connection templates for %s',
+    async ({ db, expectedType, helperSnippet, envSnippet }) => {
+      addProjectConfiguration(tree, 'api', {
+        root: 'apps/api',
+        sourceRoot: 'apps/api/src',
+        projectType: 'application',
+        targets: {},
+      });
+
+      await bootstrapGenerator(tree, {
+        project: 'api',
+        db,
+        skipInstall: true,
+      });
+
+      const helperSource = tree.read(
+        'apps/api/tools/typeorm/connection-options.ts',
+        'utf-8'
+      );
+      expect(helperSource).toContain(expectedType);
+      expect(helperSource).toContain(helperSnippet);
+
+      const envSource = tree.read('apps/api/env.example', 'utf-8');
+      expect(envSource).toContain(envSnippet);
+      expect(envSource).toContain('DATABASE_URL=');
+      expect(envSource).toContain('Mixed mode is rejected.');
+    }
+  );
+
+  it('throws for unsupported db option', async () => {
+    addProjectConfiguration(tree, 'api', {
+      root: 'apps/api',
+      sourceRoot: 'apps/api/src',
+      projectType: 'application',
+      targets: {},
+    });
+
+    await expect(
+      bootstrapGenerator(tree, {
+        project: 'api',
+        db: 'oracle' as unknown as 'postgres',
+        skipInstall: true,
+      })
+    ).rejects.toThrow(
+      'Unsupported database "oracle". Supported values: postgres, mysql, mariadb, sqlite, better-sqlite3, mssql, postgresql.'
+    );
   });
 
   it('scaffolds library assets and metadata when domain provided', async () => {

--- a/packages/typeorm/src/generators/bootstrap/generator.ts
+++ b/packages/typeorm/src/generators/bootstrap/generator.ts
@@ -30,7 +30,9 @@ interface BootstrapGeneratorSchema {
   project: string;
   domain?: string;
   schema?: string;
-  db?: string;
+  db?:
+    | SupportedDatabase
+    | 'postgresql';
   withCompose?: boolean;
   skipInstall?: boolean;
   schemaPath?: string;
@@ -39,20 +41,37 @@ interface BootstrapGeneratorSchema {
 
 const generatorDir = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_DATABASE = 'postgres';
+const DATABASE_ALIAS_MAP = {
+  postgresql: 'postgres',
+} as const;
+const SUPPORTED_DATABASES = [
+  'postgres',
+  'mysql',
+  'mariadb',
+  'sqlite',
+  'better-sqlite3',
+  'mssql',
+] as const;
 const DEFAULT_SCHEMA_PATH = 'src/infrastructure-persistence/schema.ts';
 const DEFAULT_MIGRATIONS_DIR = 'src/infrastructure-persistence/migrations';
 const DEFAULT_MIGRATION_FILE = '1700000000000_init_schema.ts';
+const APP_MIGRATIONS_DATASOURCE_PATH = 'tools/typeorm/datasource.migrations.ts';
 const runtimeImportPath = './data-source';
+const SUPPORTED_DATABASE_DISPLAY = [
+  ...SUPPORTED_DATABASES,
+  'postgresql',
+].join(', ');
+
+type SupportedDatabase = (typeof SUPPORTED_DATABASES)[number];
 
 const DRIVER_DEPENDENCIES: Record<
-  string,
+  SupportedDatabase,
   {
     packageName: string;
     version: string;
   }
 > = {
   postgres: { packageName: 'pg', version: '^8.20.0' },
-  postgresql: { packageName: 'pg', version: '^8.20.0' },
   mysql: { packageName: 'mysql2', version: '^3.20.0' },
   mariadb: { packageName: 'mariadb', version: '^3.5.2' },
   sqlite: { packageName: 'sqlite3', version: '^6.0.1' },
@@ -64,6 +83,7 @@ export default async function bootstrapGenerator(
   tree: Tree,
   options: BootstrapGeneratorSchema
 ) {
+  const database = normalizeDatabase(options.db);
   const project = readProjectConfiguration(tree, options.project);
   const isNestApplication =
     project.projectType === 'application' &&
@@ -72,7 +92,7 @@ export default async function bootstrapGenerator(
   const tasks: GeneratorCallback[] = [];
   const dependencyTask = addDependenciesToPackageJson(
     tree,
-    buildRuntimeDependencies(options.db, isNestApplication),
+    buildRuntimeDependencies(database, isNestApplication),
     {
       'ts-node': '^10.9.2',
       'typeorm-ts-node-commonjs': '^0.3.20',
@@ -91,7 +111,10 @@ export default async function bootstrapGenerator(
       tree,
       project.root,
       project.sourceRoot,
-      options,
+      {
+        ...options,
+        db: database,
+      },
       isNestApplication
     );
   }
@@ -102,19 +125,16 @@ export default async function bootstrapGenerator(
 }
 
 function buildRuntimeDependencies(
-  database: string | undefined,
+  database: SupportedDatabase,
   isNestApplication: boolean
 ) {
-  const resolvedDatabase = (database ?? DEFAULT_DATABASE).toLowerCase();
   const dependencies: Record<string, string> = {
     typeorm: '^0.3.28',
     'reflect-metadata': '^0.2.2',
   };
 
-  const driverDependency = DRIVER_DEPENDENCIES[resolvedDatabase];
-  if (driverDependency) {
-    dependencies[driverDependency.packageName] = driverDependency.version;
-  }
+  const driverDependency = DRIVER_DEPENDENCIES[database];
+  dependencies[driverDependency.packageName] = driverDependency.version;
 
   if (isNestApplication) {
     dependencies['@nestjs/typeorm'] = '^11.0.0';
@@ -201,8 +221,15 @@ function prepareApplication(
   options: BootstrapGeneratorSchema,
   isNestApplication: boolean
 ) {
-  const database = options.db ?? DEFAULT_DATABASE;
+  const database = normalizeDatabase(options.db);
   const projectName = names(options.project).fileName.replace(/-/g, '_');
+  const migrationsDatasourcePath = joinPathFragments(
+    projectRoot,
+    APP_MIGRATIONS_DATASOURCE_PATH
+  );
+  const existingMigrationsDatasource = tree.exists(migrationsDatasourcePath)
+    ? tree.read(migrationsDatasourcePath)
+    : null;
 
   generateFiles(
     tree,
@@ -215,6 +242,10 @@ function prepareApplication(
     }
   );
 
+  if (existingMigrationsDatasource) {
+    tree.write(migrationsDatasourcePath, existingMigrationsDatasource);
+  }
+
   if (!options.withCompose) {
     const composePath = joinPathFragments(projectRoot, 'docker-compose.yml');
     if (tree.exists(composePath)) {
@@ -225,6 +256,21 @@ function prepareApplication(
   if (isNestApplication) {
     patchAppModule(tree, projectRoot, sourceRoot);
   }
+}
+
+function normalizeDatabase(database?: string): SupportedDatabase {
+  const normalized = (database ?? DEFAULT_DATABASE).trim().toLowerCase();
+  const aliased =
+    DATABASE_ALIAS_MAP[normalized as keyof typeof DATABASE_ALIAS_MAP] ??
+    normalized;
+
+  if (SUPPORTED_DATABASES.includes(aliased as SupportedDatabase)) {
+    return aliased as SupportedDatabase;
+  }
+
+  throw new Error(
+    `Unsupported database "${database ?? DEFAULT_DATABASE}". Supported values: ${SUPPORTED_DATABASE_DISPLAY}.`
+  );
 }
 
 function consumeProjectJsonPartial(

--- a/packages/typeorm/src/generators/bootstrap/schema.d.ts
+++ b/packages/typeorm/src/generators/bootstrap/schema.d.ts
@@ -2,7 +2,14 @@ export interface BootstrapGeneratorSchema {
   project: string;
   domain?: string;
   schema?: string;
-  db?: string;
+  db?:
+    | 'postgres'
+    | 'postgresql'
+    | 'mysql'
+    | 'mariadb'
+    | 'sqlite'
+    | 'better-sqlite3'
+    | 'mssql';
   withCompose?: boolean;
   skipInstall?: boolean;
   schemaPath?: string;

--- a/packages/typeorm/src/generators/bootstrap/schema.json
+++ b/packages/typeorm/src/generators/bootstrap/schema.json
@@ -18,7 +18,16 @@
     },
     "db": {
       "type": "string",
-      "description": "Database type passed to TypeORM.",
+      "description": "Database type used for generated datasource connection templates.",
+      "enum": [
+        "postgres",
+        "postgresql",
+        "mysql",
+        "mariadb",
+        "sqlite",
+        "better-sqlite3",
+        "mssql"
+      ],
       "default": "postgres"
     },
     "withCompose": {


### PR DESCRIPTION
add shared tools/typeorm/connection-options.ts template for app bootstrap replace DATABASE_URL-only datasource templates with helper-based options support URL mode and discrete TYPEORM_* mode with mixed-mode rejection add exhaustive per-db option generation for postgres/mysql/mariadb/sqlite/better-sqlite3/mssql normalize --db=postgresql to postgres and fail on unsupported db values make env.example db-specific with comprehensive URL/discrete examples update bootstrap schema typings/enums and README docs extend unit and e2e coverage for db matrix, alias handling, and validation behavior