### PR TITLE
feat(nx-governance): implement weighted signal aggregation for metrics

### DIFF
--- a/packages/governance/README.md
+++ b/packages/governance/README.md
@@ -584,14 +584,39 @@ Any metric scoring below 60 is listed as a **hotspot** in both CLI and JSON outp
 
 | Metric id                    | Name                       | Direction        | Formula                                                                |
 | ---------------------------- | -------------------------- | ---------------- | ---------------------------------------------------------------------- |
-| `architectural-entropy`      | Architectural Entropy      | lower is better  | `(total violations) / max(total dependencies, 1)` → inverted to score  |
-| `dependency-complexity`      | Dependency Complexity      | lower is better  | `(total dependencies) / (projects × 4)` → inverted to score            |
-| `domain-integrity`           | Domain Integrity           | lower is better  | `(domain violations) / max(total dependencies, 1)` → inverted to score |
+| `architectural-entropy`      | Architectural Entropy      | lower is better  | `(weighted negative signal burden) / max(structural dependency volume, 1)` → inverted to score |
+| `dependency-complexity`      | Dependency Complexity      | lower is better  | `(structural dependency volume) / (projects × 4)` → inverted to score |
+| `domain-integrity`           | Domain Integrity           | lower is better  | `(weighted domain-boundary burden) / max(structural dependency volume, 1)` → inverted to score |
 | `ownership-coverage`         | Ownership Coverage         | higher is better | `(owned projects) / (total projects)` → direct score                   |
 | `documentation-completeness` | Documentation Completeness | higher is better | `(documented projects) / (total projects)` → direct score              |
-| `layer-integrity`            | Layer Integrity            | lower is better  | `(layer violations) / max(total dependencies, 1)` → inverted to score  |
+| `layer-integrity`            | Layer Integrity            | lower is better  | `(weighted layer-boundary burden) / max(structural dependency volume, 1)` → inverted to score  |
 
 All raw values are bounded to `[0, 1]` before scoring. "Lower is better" metrics are scored as `(1 − value) × 100`. "Higher is better" metrics are scored as `value × 100`.
+
+Negative signal-driven metrics use deterministic internal weighting before scoring.
+
+### Default signal aggregation weights
+
+Severity weights:
+
+| Severity | Weight |
+| -------- | ------ |
+| `info`   | `0.25` |
+| `warning`| `0.6`  |
+| `error`  | `1.0`  |
+
+Type weights:
+
+| Signal type                 | Weight | Notes |
+| --------------------------- | ------ | ----- |
+| `structural-dependency`     | `1.0`  | Used for dependency volume only, excluded from entropy penalty burden |
+| `cross-domain-dependency`   | `0.7`  | Contributes to entropy as a graph warning signal |
+| `missing-domain-context`    | `0.85` | Contributes to entropy as a graph warning signal |
+| `circular-dependency`       | `1.0`  | Reserved for future negative graph signals |
+| `conformance-violation`     | `1.0`  | Full-weight conformance penalty |
+| `domain-boundary-violation` | `1.0`  | Full-weight domain policy penalty |
+| `layer-boundary-violation`  | `0.75` | Reduced but material layer penalty |
+| `ownership-gap`             | `0.5`  | Used in entropy only; ownership coverage remains workspace-derived |
 
 ### How to interpret metrics
 
@@ -599,12 +624,12 @@ Use the overall health score for prioritization, then make decisions at the metr
 
 | Metric                       | What it measures in practice                                                 | Watch signal                                                                           | First remediation moves                                                                                                      |
 | ---------------------------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `architectural-entropy`      | Density of policy violations relative to dependency volume.                  | Rising entropy with stable project count usually means boundary discipline is eroding. | Triage top violation clusters, fix highest-fanout offenders first, then add CI gates for recurring rule ids.                 |
+| `architectural-entropy`      | Weighted negative signal burden relative to dependency volume.               | Rising entropy with stable project count usually means boundary discipline is eroding. | Triage top violation clusters, fix highest-fanout offenders first, then add CI gates for recurring rule ids.                 |
 | `dependency-complexity`      | How connected the workspace is compared with its size.                       | High complexity with frequent cross-domain work indicates large blast radius risk.     | Reduce fanout in shared nodes, split overloaded libraries, tighten public APIs.                                              |
-| `domain-integrity`           | Fraction of dependencies that break domain constraints.                      | Any sustained increase usually signals implicit coupling between domains.              | Introduce explicit inter-domain contracts, route integrations through APIs, align reviews to domain ownership.               |
+| `domain-integrity`           | Weighted burden of domain-boundary violations relative to dependency volume. | Any sustained increase usually signals implicit coupling between domains.              | Introduce explicit inter-domain contracts, route integrations through APIs, align reviews to domain ownership.               |
 | `ownership-coverage`         | Portion of projects with explicit ownership metadata or CODEOWNERS coverage. | Coverage below target slows incident response and architecture decisions.              | Fill ownership gaps first in hotspot projects, then enforce ownership checks in CI.                                          |
 | `documentation-completeness` | Portion of projects with documented architecture/context metadata.           | Low documentation on high-change projects increases onboarding and regression risk.    | Prioritize docs for critical and high-fanout projects, add minimum documentation policy for new projects.                    |
-| `layer-integrity`            | Fraction of dependencies violating layer ordering rules.                     | Repeated layer leaks often precede test brittleness and circular dependency pressure.  | Introduce layer-facing interfaces, move implementation details downward, block upward imports in lint and governance checks. |
+| `layer-integrity`            | Weighted burden of layer-boundary violations relative to dependency volume.  | Repeated layer leaks often precede test brittleness and circular dependency pressure.  | Introduce layer-facing interfaces, move implementation details downward, block upward imports in lint and governance checks. |
 
 #### Quick threshold guide
 

--- a/packages/governance/ROADMAP.md
+++ b/packages/governance/ROADMAP.md
@@ -19,26 +19,26 @@ Goal:
 
 ## Graph Integration
 
-- [ ] Implement `GraphAdapter`
-- [ ] Load Nx project graph (API or JSON)
-- [ ] Normalize projects → `GovernedProject`
-- [ ] Normalize dependencies → `GovernedDependency`
-- [ ] Add domain/layer inference from tags
-- [ ] Produce `WorkspaceGraphSnapshot`
+- [x] Implement `GraphAdapter`
+- [x] Load Nx project graph (API or JSON)
+- [x] Normalize projects → `GovernedProject`
+- [x] Normalize dependencies → `GovernedDependency`
+- [x] Add domain/layer inference from tags
+- [x] Produce `WorkspaceGraphSnapshot`
 
 ## Conformance Integration
 
-- [ ] Implement `ConformanceAdapter`
-- [ ] Support JSON-based ingestion
-- [ ] Map rule violations → `GovernanceSignal`
-- [ ] Normalize severity levels
-- [ ] Capture rule metadata
+- [x] Implement `ConformanceAdapter`
+- [x] Support JSON-based ingestion
+- [x] Map rule violations → `GovernanceSignal`
+- [x] Normalize severity levels
+- [x] Capture rule metadata
 
 ## Signal Unification
 
-- [ ] Define `GovernanceSignal` contract in core
-- [ ] Merge graph + conformance signals
-- [ ] Ensure signals are explainable and traceable
+- [x] Define `GovernanceSignal` contract in core
+- [x] Merge graph + conformance signals
+- [x] Ensure signals are explainable and traceable
 
 ## Reporting
 
@@ -59,7 +59,7 @@ Goal:
 - [ ] Redefine **Ownership Coverage Score**
   - [ ] Metadata + rule violations
 - [ ] Redefine **Dependency Complexity Score**
-  - [ ] Graph-driven
+  - [x] Graph-driven
 
 ## New Metrics
 
@@ -69,9 +69,9 @@ Goal:
 
 ## Health Engine
 
-- [ ] Implement weighted scoring
-- [ ] Aggregate signals into health scores
-- [ ] Detect hotspots (top offenders)
+- [x] Implement weighted scoring
+- [x] Aggregate signals into health scores
+- [x] Detect hotspots (top offenders)
 
 ---
 
@@ -168,12 +168,12 @@ It DOES:
 
 👉 Start with:
 
-- [ ] GraphAdapter (minimal working version)
-- [ ] CLI output: project + dependency count
+- [x] GraphAdapter (minimal working version)
+- [x] CLI output: project + dependency count
 
 Then:
 
-- [ ] ConformanceAdapter (JSON ingestion)
+- [x] ConformanceAdapter (JSON ingestion)
 - [ ] Integrate into reporting
 
 ---

--- a/packages/governance/src/metric-engine/aggregate-signals.spec.ts
+++ b/packages/governance/src/metric-engine/aggregate-signals.spec.ts
@@ -1,0 +1,242 @@
+import { GovernanceSignal } from '../signal-engine/index.js';
+
+import {
+  aggregateSignals,
+  isEntropyPenaltyAggregate,
+  sumSignalAggregateWeights,
+} from './aggregate-signals.js';
+
+describe('aggregateSignals', () => {
+  it('groups repeated signals by deterministic source, type, severity, and project scope', () => {
+    const aggregates = aggregateSignals([
+      signal({
+        id: 'policy-b',
+        source: 'policy',
+        type: 'ownership-gap',
+        severity: 'warning',
+        sourceProjectId: 'z-project',
+      }),
+      signal({
+        id: 'graph-a-1',
+        source: 'graph',
+        type: 'cross-domain-dependency',
+        severity: 'warning',
+        sourceProjectId: 'a-project',
+        targetProjectId: 'b-project',
+      }),
+      signal({
+        id: 'graph-a-2',
+        source: 'graph',
+        type: 'cross-domain-dependency',
+        severity: 'warning',
+        sourceProjectId: 'a-project',
+        targetProjectId: 'b-project',
+      }),
+      signal({
+        id: 'conformance-a',
+        source: 'conformance',
+        type: 'conformance-violation',
+        severity: 'error',
+        sourceProjectId: 'm-project',
+        targetProjectId: 'n-project',
+      }),
+    ]);
+
+    expect(
+      aggregates.map(
+        (aggregate) =>
+          `${aggregate.source}|${aggregate.type}|${aggregate.severity}|${aggregate.sourceProjectId ?? ''}|${aggregate.targetProjectId ?? ''}|${aggregate.count}`
+      )
+    ).toEqual([
+      'graph|cross-domain-dependency|warning|a-project|b-project|2',
+      'conformance|conformance-violation|error|m-project|n-project|1',
+      'policy|ownership-gap|warning|z-project||1',
+    ]);
+  });
+
+  it('produces stable aggregate totals independent of input order', () => {
+    const first = aggregateSignals([
+      signal({
+        id: '1',
+        source: 'graph',
+        type: 'missing-domain-context',
+        severity: 'warning',
+        sourceProjectId: 'a',
+        targetProjectId: 'b',
+      }),
+      signal({
+        id: '2',
+        source: 'graph',
+        type: 'missing-domain-context',
+        severity: 'warning',
+        sourceProjectId: 'a',
+        targetProjectId: 'b',
+      }),
+      signal({
+        id: '3',
+        source: 'policy',
+        type: 'layer-boundary-violation',
+        severity: 'warning',
+        sourceProjectId: 'b',
+        targetProjectId: 'c',
+      }),
+    ]);
+    const second = aggregateSignals([
+      signal({
+        id: '3',
+        source: 'policy',
+        type: 'layer-boundary-violation',
+        severity: 'warning',
+        sourceProjectId: 'b',
+        targetProjectId: 'c',
+      }),
+      signal({
+        id: '2',
+        source: 'graph',
+        type: 'missing-domain-context',
+        severity: 'warning',
+        sourceProjectId: 'a',
+        targetProjectId: 'b',
+      }),
+      signal({
+        id: '1',
+        source: 'graph',
+        type: 'missing-domain-context',
+        severity: 'warning',
+        sourceProjectId: 'a',
+        targetProjectId: 'b',
+      }),
+    ]);
+
+    expect(first).toEqual(second);
+  });
+
+  it('applies fixed type and severity weights for mixed signal sets', () => {
+    const aggregates = aggregateSignals([
+      signal({
+        id: 'info-structural',
+        source: 'graph',
+        type: 'structural-dependency',
+        severity: 'info',
+        sourceProjectId: 'a',
+        targetProjectId: 'b',
+      }),
+      signal({
+        id: 'warning-cross',
+        source: 'graph',
+        type: 'cross-domain-dependency',
+        severity: 'warning',
+        sourceProjectId: 'a',
+        targetProjectId: 'c',
+      }),
+      signal({
+        id: 'error-conformance',
+        source: 'conformance',
+        type: 'conformance-violation',
+        severity: 'error',
+        sourceProjectId: 'c',
+        targetProjectId: 'd',
+      }),
+      signal({
+        id: 'warning-ownership',
+        source: 'policy',
+        type: 'ownership-gap',
+        severity: 'warning',
+        sourceProjectId: 'z',
+      }),
+    ]);
+
+    expect(
+      aggregates.map((aggregate) => ({
+        type: aggregate.type,
+        severity: aggregate.severity,
+        unitWeight: aggregate.unitWeight,
+        totalWeight: aggregate.totalWeight,
+      }))
+    ).toEqual([
+      {
+        type: 'cross-domain-dependency',
+        severity: 'warning',
+        unitWeight: 0.42,
+        totalWeight: 0.42,
+      },
+      {
+        type: 'structural-dependency',
+        severity: 'info',
+        unitWeight: 0.25,
+        totalWeight: 0.25,
+      },
+      {
+        type: 'conformance-violation',
+        severity: 'error',
+        unitWeight: 1,
+        totalWeight: 1,
+      },
+      {
+        type: 'ownership-gap',
+        severity: 'warning',
+        unitWeight: 0.3,
+        totalWeight: 0.3,
+      },
+    ]);
+  });
+
+  it('excludes structural dependencies from entropy penalty totals', () => {
+    const aggregates = aggregateSignals([
+      signal({
+        id: 'structural',
+        source: 'graph',
+        type: 'structural-dependency',
+        severity: 'info',
+        sourceProjectId: 'a',
+        targetProjectId: 'b',
+      }),
+      signal({
+        id: 'missing-domain',
+        source: 'graph',
+        type: 'missing-domain-context',
+        severity: 'warning',
+        sourceProjectId: 'a',
+        targetProjectId: 'b',
+      }),
+      signal({
+        id: 'policy-domain',
+        source: 'policy',
+        type: 'domain-boundary-violation',
+        severity: 'error',
+        sourceProjectId: 'a',
+        targetProjectId: 'c',
+      }),
+    ]);
+
+    expect(
+      sumSignalAggregateWeights(aggregates, isEntropyPenaltyAggregate)
+    ).toBe(1.51);
+  });
+});
+
+function signal(
+  overrides: Partial<GovernanceSignal> &
+    Pick<GovernanceSignal, 'id' | 'source' | 'type' | 'severity'>
+): GovernanceSignal {
+  const sourceProjectId = overrides.sourceProjectId;
+  const targetProjectId = overrides.targetProjectId;
+
+  return {
+    id: overrides.id,
+    source: overrides.source,
+    type: overrides.type,
+    severity: overrides.severity,
+    category: overrides.category ?? 'boundary',
+    message: overrides.message ?? overrides.id,
+    sourceProjectId,
+    targetProjectId,
+    relatedProjectIds:
+      overrides.relatedProjectIds ??
+      [sourceProjectId, targetProjectId]
+        .filter((value): value is string => Boolean(value))
+        .sort((a, b) => a.localeCompare(b)),
+    metadata: overrides.metadata,
+    createdAt: overrides.createdAt ?? '2026-03-30T00:00:00.000Z',
+  };
+}

--- a/packages/governance/src/metric-engine/aggregate-signals.ts
+++ b/packages/governance/src/metric-engine/aggregate-signals.ts
@@ -1,0 +1,158 @@
+import {
+  GovernanceSignal,
+  GovernanceSignalSeverity,
+  GovernanceSignalSource,
+  GovernanceSignalType,
+} from '../signal-engine/index.js';
+
+export interface SignalAggregate {
+  key: string;
+  source: GovernanceSignalSource;
+  type: GovernanceSignalType;
+  severity: GovernanceSignalSeverity;
+  sourceProjectId?: string;
+  targetProjectId?: string;
+  relatedProjectIds: string[];
+  count: number;
+  unitWeight: number;
+  totalWeight: number;
+}
+
+const SOURCE_SORT_ORDER: Record<GovernanceSignalSource, number> = {
+  graph: 0,
+  conformance: 1,
+  policy: 2,
+};
+
+const SEVERITY_SORT_ORDER: Record<GovernanceSignalSeverity, number> = {
+  info: 0,
+  warning: 1,
+  error: 2,
+};
+
+const SIGNAL_SEVERITY_WEIGHTS: Record<GovernanceSignalSeverity, number> = {
+  info: 0.25,
+  warning: 0.6,
+  error: 1.0,
+};
+
+const SIGNAL_TYPE_WEIGHTS: Record<GovernanceSignalType, number> = {
+  'structural-dependency': 1.0,
+  'cross-domain-dependency': 0.7,
+  'missing-domain-context': 0.85,
+  'circular-dependency': 1.0,
+  'conformance-violation': 1.0,
+  'domain-boundary-violation': 1.0,
+  'layer-boundary-violation': 0.75,
+  'ownership-gap': 0.5,
+};
+
+export function aggregateSignals(signals: GovernanceSignal[]): SignalAggregate[] {
+  const groupedSignals = new Map<string, SignalAggregate>();
+
+  for (const signal of signals) {
+    const key = signalAggregateKey(signal);
+    const existing = groupedSignals.get(key);
+    const unitWeight = signalWeight(signal);
+
+    if (existing) {
+      existing.count += 1;
+      existing.totalWeight = roundWeight(existing.count * existing.unitWeight);
+      continue;
+    }
+
+    groupedSignals.set(key, {
+      key,
+      source: signal.source,
+      type: signal.type,
+      severity: signal.severity,
+      sourceProjectId: signal.sourceProjectId,
+      targetProjectId: signal.targetProjectId,
+      relatedProjectIds: [...signal.relatedProjectIds],
+      count: 1,
+      unitWeight,
+      totalWeight: roundWeight(unitWeight),
+    });
+  }
+
+  return [...groupedSignals.values()].sort(compareSignalAggregates);
+}
+
+export function sumSignalAggregateCounts(
+  aggregates: SignalAggregate[],
+  predicate: (aggregate: SignalAggregate) => boolean
+): number {
+  return aggregates
+    .filter(predicate)
+    .reduce((total, aggregate) => total + aggregate.count, 0);
+}
+
+export function sumSignalAggregateWeights(
+  aggregates: SignalAggregate[],
+  predicate: (aggregate: SignalAggregate) => boolean
+): number {
+  const weightedTotal = aggregates
+    .filter(predicate)
+    .reduce((total, aggregate) => total + aggregate.totalWeight, 0);
+
+  return roundWeight(weightedTotal);
+}
+
+export function isEntropyPenaltyAggregate(aggregate: SignalAggregate): boolean {
+  return aggregate.type !== 'structural-dependency';
+}
+
+function signalAggregateKey(signal: GovernanceSignal): string {
+  return [
+    signal.source,
+    signal.type,
+    signal.severity,
+    signal.sourceProjectId ?? '',
+    signal.targetProjectId ?? '',
+    signal.relatedProjectIds.join(','),
+  ].join('|');
+}
+
+function signalWeight(signal: GovernanceSignal): number {
+  return roundWeight(
+    SIGNAL_TYPE_WEIGHTS[signal.type] * SIGNAL_SEVERITY_WEIGHTS[signal.severity]
+  );
+}
+
+function compareSignalAggregates(a: SignalAggregate, b: SignalAggregate): number {
+  const sourceOrder = SOURCE_SORT_ORDER[a.source] - SOURCE_SORT_ORDER[b.source];
+  if (sourceOrder !== 0) {
+    return sourceOrder;
+  }
+
+  const typeOrder = a.type.localeCompare(b.type);
+  if (typeOrder !== 0) {
+    return typeOrder;
+  }
+
+  const severityOrder =
+    SEVERITY_SORT_ORDER[a.severity] - SEVERITY_SORT_ORDER[b.severity];
+  if (severityOrder !== 0) {
+    return severityOrder;
+  }
+
+  const sourceProjectOrder = (a.sourceProjectId ?? '').localeCompare(
+    b.sourceProjectId ?? ''
+  );
+  if (sourceProjectOrder !== 0) {
+    return sourceProjectOrder;
+  }
+
+  const targetProjectOrder = (a.targetProjectId ?? '').localeCompare(
+    b.targetProjectId ?? ''
+  );
+  if (targetProjectOrder !== 0) {
+    return targetProjectOrder;
+  }
+
+  return a.relatedProjectIds.join(',').localeCompare(b.relatedProjectIds.join(','));
+}
+
+function roundWeight(value: number): number {
+  return Number(value.toFixed(4));
+}

--- a/packages/governance/src/metric-engine/calculate-metrics.spec.ts
+++ b/packages/governance/src/metric-engine/calculate-metrics.spec.ts
@@ -80,8 +80,8 @@ describe('calculateMetrics', () => {
     });
 
     expect(metricById(metrics, 'architectural-entropy')).toMatchObject({
-      value: 0.5,
-      score: 50,
+      value: 0.15,
+      score: 85,
     });
     expect(metricById(metrics, 'dependency-complexity')).toMatchObject({
       value: 0.25,
@@ -100,6 +100,36 @@ describe('calculateMetrics', () => {
       score: 50,
     });
     expect(metricById(metrics, 'layer-integrity')).toMatchObject({
+      value: 0,
+      score: 100,
+    });
+  });
+
+  it('counts graph warning signals in entropy without treating them as domain-integrity penalties', () => {
+    const metrics = calculateMetrics({
+      workspace,
+      signals: [
+        ...buildSignals(workspace, []),
+        {
+          id: 'graph-warning',
+          type: 'missing-domain-context' as const,
+          sourceProjectId: 'a',
+          targetProjectId: 'b',
+          relatedProjectIds: ['a', 'b'],
+          severity: 'warning' as const,
+          category: 'boundary' as const,
+          message: 'missing domain context',
+          source: 'graph' as const,
+          createdAt: '2026-03-30T00:00:00.000Z',
+        },
+      ],
+    });
+
+    expect(metricById(metrics, 'architectural-entropy')).toMatchObject({
+      value: 0.255,
+      score: 75,
+    });
+    expect(metricById(metrics, 'domain-integrity')).toMatchObject({
       value: 0,
       score: 100,
     });

--- a/packages/governance/src/metric-engine/calculate-metrics.ts
+++ b/packages/governance/src/metric-engine/calculate-metrics.ts
@@ -1,5 +1,11 @@
 import { GovernanceWorkspace, Measurement } from '../core/index.js';
 import { GovernanceSignal } from '../signal-engine/index.js';
+import {
+  aggregateSignals,
+  isEntropyPenaltyAggregate,
+  sumSignalAggregateCounts,
+  sumSignalAggregateWeights,
+} from './aggregate-signals.js';
 
 export interface MetricEngineInput {
   workspace: GovernanceWorkspace;
@@ -10,21 +16,25 @@ export function calculateMetrics(input: MetricEngineInput): Measurement[] {
   const { workspace, signals } = input;
   const dependencyCount = workspace.dependencies.length;
   const projectCount = workspace.projects.length || 1;
-  const structuralDependencyCount = signals.filter(
-    (signal) => signal.type === 'structural-dependency'
-  ).length;
+  const signalAggregates = aggregateSignals(signals);
+  const structuralDependencyCount = sumSignalAggregateCounts(
+    signalAggregates,
+    (aggregate) => aggregate.type === 'structural-dependency'
+  );
   const canonicalDependencyCount =
     structuralDependencyCount > 0 ? structuralDependencyCount : dependencyCount;
-  const policySignalCount = signals.filter(
-    (signal) => signal.source === 'policy'
-  ).length;
-
-  const layerViolations = signals.filter(
-    (signal) => signal.type === 'layer-boundary-violation'
-  ).length;
-  const domainViolations = signals.filter(
-    (signal) => signal.type === 'domain-boundary-violation'
-  ).length;
+  const entropyPenaltyWeight = sumSignalAggregateWeights(
+    signalAggregates,
+    isEntropyPenaltyAggregate
+  );
+  const layerViolationWeight = sumSignalAggregateWeights(
+    signalAggregates,
+    (aggregate) => aggregate.type === 'layer-boundary-violation'
+  );
+  const domainViolationWeight = sumSignalAggregateWeights(
+    signalAggregates,
+    (aggregate) => aggregate.type === 'domain-boundary-violation'
+  );
   const ownedProjects = workspace.projects.filter(
     (project) =>
       Boolean(project.ownership?.team) ||
@@ -40,7 +50,7 @@ export function calculateMetrics(input: MetricEngineInput): Measurement[] {
     makeScore(
       'architectural-entropy',
       'Architectural Entropy',
-      policySignalCount / Math.max(canonicalDependencyCount, 1)
+      entropyPenaltyWeight / Math.max(canonicalDependencyCount, 1)
     ),
     makeScore(
       'dependency-complexity',
@@ -50,7 +60,7 @@ export function calculateMetrics(input: MetricEngineInput): Measurement[] {
     makeScore(
       'domain-integrity',
       'Domain Integrity',
-      domainViolations / Math.max(canonicalDependencyCount, 1)
+      domainViolationWeight / Math.max(canonicalDependencyCount, 1)
     ),
     makeScore(
       'ownership-coverage',
@@ -67,7 +77,7 @@ export function calculateMetrics(input: MetricEngineInput): Measurement[] {
     makeScore(
       'layer-integrity',
       'Layer Integrity',
-      layerViolations / Math.max(canonicalDependencyCount, 1)
+      layerViolationWeight / Math.max(canonicalDependencyCount, 1)
     ),
   ];
 }


### PR DESCRIPTION
Add deterministic weighted signal aggregation to nx-governance metrics while keeping existing public metric ids and report shapes unchanged.

- weight negative governance signals by type and severity
- drive entropy, domain integrity, and layer integrity from aggregate burden
- preserve structural dependency volume for dependency complexity
- update metric tests and README formulas
- refresh roadmap status for completed graph/conformance/signal work

Closes #44 Refs #35