### PR TITLE
feat(governance): add source-aware reporting with conformance fallback

### DIFF
--- a/packages/governance/README.md
+++ b/packages/governance/README.md
@@ -301,11 +301,12 @@ nx workspace-conformance --conformanceJson=dist/conformance-result.json
 
 Base options used by governance and AI executors:
 
-| Option            | Type                | Default             | Description                                                                                                 |
-| ----------------- | ------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `profile`         | `string`            | `"angular-cleanup"` | Name of the governance profile to load from `tools/governance/profiles/`.                                   |
-| `output`          | `"cli"` \| `"json"` | `"cli"`             | Output format. `cli` prints a human-readable report via Nx logger. `json` writes structured JSON to stdout. |
-| `failOnViolation` | `boolean`           | `false`             | Exit with a non-zero code when any violation is found. Use this to gate CI.                                 |
+| Option            | Type                | Default             | Description                                                                                                                                                           |
+| ----------------- | ------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `profile`         | `string`            | `"angular-cleanup"` | Name of the governance profile to load from `tools/governance/profiles/`.                                                                                             |
+| `output`          | `"cli"` \| `"json"` | `"cli"`             | Output format. `cli` prints a human-readable report via Nx logger. `json` writes structured JSON to stdout.                                                           |
+| `failOnViolation` | `boolean`           | `false`             | Exit with a non-zero code when any violation is found. Use this to gate CI.                                                                                           |
+| `conformanceJson` | `string`            | unset               | Optional override for the Nx Conformance JSON path. If omitted, governance will try `nx.json > conformance.outputPath` before continuing without conformance signals. |
 
 Additional options are listed per command where applicable (`snapshotDir`, `snapshotPath`, `topViolations`, `topProjects`, `baseRef`, `headRef`, ...).
 
@@ -321,6 +322,10 @@ nx repo-health --failOnViolation
 
 **Metrics included:** all six (Architectural Entropy, Dependency Complexity, Domain Integrity, Ownership Coverage, Documentation Completeness, Layer Integrity).
 
+**Signal sources shown:** graph, conformance, and policy. The CLI report prints a deterministic `Signal Sources` section, and the JSON output includes `signalBreakdown.total` plus `signalBreakdown.bySource`.
+
+**Conformance input resolution:** explicit `--conformanceJson` wins. If it is not provided, governance tries `nx.json > conformance.outputPath`. If neither is available, the report still renders with a `conformance` count of `0`. If `nx.json` declares an output path but the file cannot be read, governance fails with a clear configuration error.
+
 **Use when:** you want a single number that summarises overall workspace quality, or when running a health gate in CI.
 
 ---
@@ -335,6 +340,8 @@ nx repo-boundaries --output=json --failOnViolation
 ```
 
 **Metrics included:** Architectural Entropy, Domain Integrity, Layer Integrity.
+
+**Signal sources shown:** boundary-scoped graph, conformance, and policy signals only.
 
 **Violations surfaced:**
 
@@ -356,6 +363,8 @@ nx repo-ownership --output=json
 
 **Metrics included:** Ownership Coverage.
 
+**Signal sources shown:** ownership-scoped graph, conformance, and policy signals only.
+
 **Violations surfaced:**
 
 - `ownership-presence` (severity: `warning`) — a project has neither an `ownership.team` metadata field nor a matching CODEOWNERS entry.
@@ -375,9 +384,21 @@ nx repo-architecture --output=json
 
 **Metrics included:** Architectural Entropy, Dependency Complexity, Domain Integrity.
 
+**Signal sources shown:** all non-ownership graph, conformance, and policy signals.
+
 **Violations surfaced:** all violation types _except_ `ownership-presence`.
 
 **Use when:** you want to track architectural drift over time and are not concerned with team assignment in this particular run.
+
+### Signal Source Breakdown
+
+When governance reporting is rendered, the assessment always includes a source breakdown with fixed rows in this order:
+
+- `graph`
+- `conformance`
+- `policy`
+
+Counts are scoped to the active report type. For example, `repo-boundaries` only counts boundary-category signals, while `repo-architecture` excludes ownership-category signals. If `conformanceJson` is omitted, the `conformance` row is still present with count `0`.
 
 ---
 
@@ -582,13 +603,13 @@ Any metric scoring below 60 is listed as a **hotspot** in both CLI and JSON outp
 
 ### Metrics
 
-| Metric id                    | Name                       | Direction        | Formula                                                                |
-| ---------------------------- | -------------------------- | ---------------- | ---------------------------------------------------------------------- |
+| Metric id                    | Name                       | Direction        | Formula                                                                                        |
+| ---------------------------- | -------------------------- | ---------------- | ---------------------------------------------------------------------------------------------- |
 | `architectural-entropy`      | Architectural Entropy      | lower is better  | `(weighted negative signal burden) / max(structural dependency volume, 1)` → inverted to score |
-| `dependency-complexity`      | Dependency Complexity      | lower is better  | `(structural dependency volume) / (projects × 4)` → inverted to score |
+| `dependency-complexity`      | Dependency Complexity      | lower is better  | `(structural dependency volume) / (projects × 4)` → inverted to score                          |
 | `domain-integrity`           | Domain Integrity           | lower is better  | `(weighted domain-boundary burden) / max(structural dependency volume, 1)` → inverted to score |
-| `ownership-coverage`         | Ownership Coverage         | higher is better | `(owned projects) / (total projects)` → direct score                   |
-| `documentation-completeness` | Documentation Completeness | higher is better | `(documented projects) / (total projects)` → direct score              |
+| `ownership-coverage`         | Ownership Coverage         | higher is better | `(owned projects) / (total projects)` → direct score                                           |
+| `documentation-completeness` | Documentation Completeness | higher is better | `(documented projects) / (total projects)` → direct score                                      |
 | `layer-integrity`            | Layer Integrity            | lower is better  | `(weighted layer-boundary burden) / max(structural dependency volume, 1)` → inverted to score  |
 
 All raw values are bounded to `[0, 1]` before scoring. "Lower is better" metrics are scored as `(1 − value) × 100`. "Higher is better" metrics are scored as `value × 100`.
@@ -599,24 +620,24 @@ Negative signal-driven metrics use deterministic internal weighting before scori
 
 Severity weights:
 
-| Severity | Weight |
-| -------- | ------ |
-| `info`   | `0.25` |
-| `warning`| `0.6`  |
-| `error`  | `1.0`  |
+| Severity  | Weight |
+| --------- | ------ |
+| `info`    | `0.25` |
+| `warning` | `0.6`  |
+| `error`   | `1.0`  |
 
 Type weights:
 
-| Signal type                 | Weight | Notes |
-| --------------------------- | ------ | ----- |
+| Signal type                 | Weight | Notes                                                                 |
+| --------------------------- | ------ | --------------------------------------------------------------------- |
 | `structural-dependency`     | `1.0`  | Used for dependency volume only, excluded from entropy penalty burden |
-| `cross-domain-dependency`   | `0.7`  | Contributes to entropy as a graph warning signal |
-| `missing-domain-context`    | `0.85` | Contributes to entropy as a graph warning signal |
-| `circular-dependency`       | `1.0`  | Reserved for future negative graph signals |
-| `conformance-violation`     | `1.0`  | Full-weight conformance penalty |
-| `domain-boundary-violation` | `1.0`  | Full-weight domain policy penalty |
-| `layer-boundary-violation`  | `0.75` | Reduced but material layer penalty |
-| `ownership-gap`             | `0.5`  | Used in entropy only; ownership coverage remains workspace-derived |
+| `cross-domain-dependency`   | `0.7`  | Contributes to entropy as a graph warning signal                      |
+| `missing-domain-context`    | `0.85` | Contributes to entropy as a graph warning signal                      |
+| `circular-dependency`       | `1.0`  | Reserved for future negative graph signals                            |
+| `conformance-violation`     | `1.0`  | Full-weight conformance penalty                                       |
+| `domain-boundary-violation` | `1.0`  | Full-weight domain policy penalty                                     |
+| `layer-boundary-violation`  | `0.75` | Reduced but material layer penalty                                    |
+| `ownership-gap`             | `0.5`  | Used in entropy only; ownership coverage remains workspace-derived    |
 
 ### How to interpret metrics
 

--- a/packages/governance/ROADMAP.md
+++ b/packages/governance/ROADMAP.md
@@ -42,11 +42,11 @@ Goal:
 
 ## Reporting
 
-- [ ] Show signal sources in CLI output
-- [ ] Distinguish:
-  - [ ] Graph findings
-  - [ ] Conformance findings
-- [ ] Add counts per source
+- [x] Show signal sources in CLI output
+- [x] Distinguish:
+  - [x] Graph findings
+  - [x] Conformance findings
+- [x] Add counts per source
 
 ---
 
@@ -175,6 +175,6 @@ It DOES:
 Then:
 
 - [x] ConformanceAdapter (JSON ingestion)
-- [ ] Integrate into reporting
+- [x] Integrate into reporting
 
 ---

--- a/packages/governance/src/core/models.ts
+++ b/packages/governance/src/core/models.ts
@@ -63,12 +63,23 @@ export interface HealthScore {
   hotspots: string[];
 }
 
+export interface SignalBreakdownEntry {
+  source: 'graph' | 'conformance' | 'policy';
+  count: number;
+}
+
+export interface SignalBreakdown {
+  total: number;
+  bySource: SignalBreakdownEntry[];
+}
+
 export interface GovernanceAssessment {
   workspace: GovernanceWorkspace;
   profile: string;
   warnings: string[];
   violations: Violation[];
   measurements: Measurement[];
+  signalBreakdown: SignalBreakdown;
   health: HealthScore;
   recommendations: Recommendation[];
 }

--- a/packages/governance/src/executors/repo-architecture/schema.json
+++ b/packages/governance/src/executors/repo-architecture/schema.json
@@ -17,6 +17,10 @@
       "type": "boolean",
       "default": false,
       "description": "Exit with failure if violations are found."
+    },
+    "conformanceJson": {
+      "type": "string",
+      "description": "Optional override for the Nx Conformance JSON path. Falls back to nx.json conformance.outputPath when omitted."
     }
   },
   "additionalProperties": false

--- a/packages/governance/src/executors/repo-boundaries/schema.json
+++ b/packages/governance/src/executors/repo-boundaries/schema.json
@@ -17,6 +17,10 @@
       "type": "boolean",
       "default": false,
       "description": "Exit with failure if violations are found."
+    },
+    "conformanceJson": {
+      "type": "string",
+      "description": "Optional override for the Nx Conformance JSON path. Falls back to nx.json conformance.outputPath when omitted."
     }
   },
   "additionalProperties": false

--- a/packages/governance/src/executors/repo-health/schema.json
+++ b/packages/governance/src/executors/repo-health/schema.json
@@ -17,6 +17,10 @@
       "type": "boolean",
       "default": false,
       "description": "Exit with failure if violations are found."
+    },
+    "conformanceJson": {
+      "type": "string",
+      "description": "Optional override for the Nx Conformance JSON path. Falls back to nx.json conformance.outputPath when omitted."
     }
   },
   "additionalProperties": false

--- a/packages/governance/src/executors/repo-ownership/schema.json
+++ b/packages/governance/src/executors/repo-ownership/schema.json
@@ -17,6 +17,10 @@
       "type": "boolean",
       "default": false,
       "description": "Exit with failure if violations are found."
+    },
+    "conformanceJson": {
+      "type": "string",
+      "description": "Optional override for the Nx Conformance JSON path. Falls back to nx.json conformance.outputPath when omitted."
     }
   },
   "additionalProperties": false

--- a/packages/governance/src/executors/shared.ts
+++ b/packages/governance/src/executors/shared.ts
@@ -12,6 +12,7 @@ export async function runGovernanceExecutor(
     profile: options.profile,
     output: options.output,
     failOnViolation: options.failOnViolation,
+    conformanceJson: options.conformanceJson,
     reportType,
   });
 

--- a/packages/governance/src/executors/types.ts
+++ b/packages/governance/src/executors/types.ts
@@ -2,6 +2,7 @@ export interface GovernanceExecutorOptions {
   profile?: string;
   output?: 'cli' | 'json';
   failOnViolation?: boolean;
+  conformanceJson?: string;
 }
 
 export interface GovernanceSnapshotExecutorOptions

--- a/packages/governance/src/plugin/resolve-conformance-input.ts
+++ b/packages/governance/src/plugin/resolve-conformance-input.ts
@@ -1,0 +1,63 @@
+import { workspaceRoot } from '@nx/devkit';
+import * as fs from 'node:fs';
+import path from 'node:path';
+
+export interface ResolvedConformanceInput {
+  conformanceJson?: string;
+  source: 'explicit' | 'nx-json' | 'none';
+}
+
+export function resolveConformanceInput(
+  explicitConformanceJson?: string
+): ResolvedConformanceInput {
+  if (explicitConformanceJson) {
+    return {
+      conformanceJson: explicitConformanceJson,
+      source: 'explicit',
+    };
+  }
+
+  const outputPath = readNxJsonConformanceOutputPath();
+  if (!outputPath) {
+    return {
+      conformanceJson: undefined,
+      source: 'none',
+    };
+  }
+
+  return {
+    conformanceJson: outputPath,
+    source: 'nx-json',
+  };
+}
+
+function readNxJsonConformanceOutputPath(): string | undefined {
+  const nxJsonPath = path.join(workspaceRoot, 'nx.json');
+
+  try {
+    const raw = fs.readFileSync(nxJsonPath, 'utf8');
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const conformance = asRecord(parsed.conformance);
+    const outputPath = conformance?.outputPath;
+
+    return typeof outputPath === 'string' && outputPath.trim().length > 0
+      ? outputPath
+      : undefined;
+  } catch (error) {
+    throw new Error(
+      `Unable to read Nx Conformance configuration from ${nxJsonPath}: ${toErrorMessage(
+        error
+      )}`
+    );
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Unknown error.';
+}

--- a/packages/governance/src/plugin/run-governance.spec.ts
+++ b/packages/governance/src/plugin/run-governance.spec.ts
@@ -1,3 +1,8 @@
+import * as fs from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
 import { logger, workspaceRoot } from '@nx/devkit';
 
 import { calculateHealthScore } from '../health-engine/calculate-health.js';
@@ -64,6 +69,202 @@ describe('runGovernance', () => {
 
     expect(health.assessment.health).toEqual(
       calculateHealthScore(health.assessment.measurements, resolvedWeights)
+    );
+    expect(health.assessment.signalBreakdown.bySource).toEqual([
+      {
+        source: 'graph',
+        count: health.assessment.signalBreakdown.bySource[0].count,
+      },
+      { source: 'conformance', count: 0 },
+      {
+        source: 'policy',
+        count: health.assessment.signalBreakdown.bySource[2].count,
+      },
+    ]);
+  });
+
+  it('loads conformance signals into the assessment pipeline when conformanceJson is provided', async () => {
+    jest.spyOn(logger, 'info').mockImplementation(() => undefined);
+
+    const tempDir = mkdtempSync(
+      path.join(tmpdir(), 'nx-governance-conformance-')
+    );
+    const conformanceJson = path.join(tempDir, 'conformance.json');
+
+    writeFileSync(
+      conformanceJson,
+      JSON.stringify([
+        {
+          id: 'finding-1',
+          ruleId: '@nx/conformance/enforce-project-boundaries',
+          severity: 'error',
+          message: 'Conformance boundary violation',
+          projectId: 'packages/governance',
+        },
+      ])
+    );
+
+    try {
+      const baseline = await runGovernance({ reportType: 'health' });
+      const withConformance = await runGovernance({
+        reportType: 'health',
+        conformanceJson,
+      });
+
+      expect(
+        baseline.assessment.signalBreakdown.bySource.find(
+          (entry) => entry.source === 'conformance'
+        )
+      ).toEqual({ source: 'conformance', count: 0 });
+      expect(
+        withConformance.assessment.signalBreakdown.bySource.find(
+          (entry) => entry.source === 'conformance'
+        )
+      ).toEqual({ source: 'conformance', count: 1 });
+
+      const baselineEntropy = baseline.assessment.measurements.find(
+        (metric) => metric.id === 'architectural-entropy'
+      );
+      const conformanceEntropy = withConformance.assessment.measurements.find(
+        (metric) => metric.id === 'architectural-entropy'
+      );
+
+      expect(conformanceEntropy?.value).toBeGreaterThan(
+        baselineEntropy?.value ?? 0
+      );
+      expect(withConformance.assessment.health.score).toBeLessThanOrEqual(
+        baseline.assessment.health.score
+      );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('auto-discovers conformance output from nx.json when no override is provided', async () => {
+    jest.spyOn(logger, 'info').mockImplementation(() => undefined);
+
+    const tempDir = mkdtempSync(
+      path.join(tmpdir(), 'nx-governance-conformance-')
+    );
+    const conformanceJson = path.join(tempDir, 'conformance.json');
+    const nxJsonPath = path.join(workspaceRoot, 'nx.json');
+    const actualReadFileSync = fs.readFileSync;
+
+    writeFileSync(
+      conformanceJson,
+      JSON.stringify([
+        {
+          id: 'finding-1',
+          ruleId: '@nx/conformance/enforce-project-boundaries',
+          severity: 'error',
+          message: 'Conformance boundary violation',
+          projectId: 'packages/governance',
+        },
+      ])
+    );
+
+    jest.spyOn(fs, 'readFileSync').mockImplementation(((filePath, encoding) => {
+      if (path.resolve(String(filePath)) === nxJsonPath) {
+        return JSON.stringify({
+          conformance: {
+            outputPath: conformanceJson,
+          },
+        });
+      }
+
+      return actualReadFileSync(filePath, encoding as never);
+    }) as typeof fs.readFileSync);
+
+    try {
+      const baseline = await runGovernance({ reportType: 'health' });
+      const discovered = await runGovernance({ reportType: 'health' });
+
+      expect(
+        baseline.assessment.signalBreakdown.bySource.find(
+          (entry) => entry.source === 'conformance'
+        )
+      ).toEqual({ source: 'conformance', count: 1 });
+      expect(
+        discovered.assessment.signalBreakdown.bySource.find(
+          (entry) => entry.source === 'conformance'
+        )
+      ).toEqual({ source: 'conformance', count: 1 });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('prefers explicit conformanceJson over nx.json outputPath', async () => {
+    jest.spyOn(logger, 'info').mockImplementation(() => undefined);
+
+    const tempDir = mkdtempSync(
+      path.join(tmpdir(), 'nx-governance-conformance-')
+    );
+    const explicitConformanceJson = path.join(tempDir, 'explicit.json');
+    const nxJsonPath = path.join(workspaceRoot, 'nx.json');
+    const actualReadFileSync = fs.readFileSync;
+
+    writeFileSync(
+      explicitConformanceJson,
+      JSON.stringify([
+        {
+          id: 'finding-1',
+          ruleId: '@nx/conformance/enforce-project-boundaries',
+          severity: 'error',
+          message: 'Conformance boundary violation',
+          projectId: 'packages/governance',
+        },
+      ])
+    );
+
+    jest.spyOn(fs, 'readFileSync').mockImplementation(((filePath, encoding) => {
+      if (path.resolve(String(filePath)) === nxJsonPath) {
+        return JSON.stringify({
+          conformance: {
+            outputPath: 'dist/missing-conformance.json',
+          },
+        });
+      }
+
+      return actualReadFileSync(filePath, encoding as never);
+    }) as typeof fs.readFileSync);
+
+    try {
+      const result = await runGovernance({
+        reportType: 'health',
+        conformanceJson: explicitConformanceJson,
+      });
+
+      expect(
+        result.assessment.signalBreakdown.bySource.find(
+          (entry) => entry.source === 'conformance'
+        )
+      ).toEqual({ source: 'conformance', count: 1 });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails clearly when nx.json config points to a missing conformance file', async () => {
+    jest.spyOn(logger, 'info').mockImplementation(() => undefined);
+
+    const nxJsonPath = path.join(workspaceRoot, 'nx.json');
+    const actualReadFileSync = fs.readFileSync;
+
+    jest.spyOn(fs, 'readFileSync').mockImplementation(((filePath, encoding) => {
+      if (path.resolve(String(filePath)) === nxJsonPath) {
+        return JSON.stringify({
+          conformance: {
+            outputPath: 'dist/missing-conformance.json',
+          },
+        });
+      }
+
+      return actualReadFileSync(filePath, encoding as never);
+    }) as typeof fs.readFileSync);
+
+    await expect(runGovernance({ reportType: 'health' })).rejects.toThrow(
+      'Unable to load Nx Conformance output configured in nx.json'
     );
   });
 });

--- a/packages/governance/src/plugin/run-governance.ts
+++ b/packages/governance/src/plugin/run-governance.ts
@@ -16,6 +16,10 @@ import {
 } from '../presets/angular-cleanup/profile.js';
 import { renderCliReport } from '../reporting/render-cli.js';
 import { renderJsonReport } from '../reporting/render-json.js';
+import {
+  buildSignalBreakdown,
+  filterSignalsForReportType,
+} from '../reporting/signal-breakdown.js';
 import { MetricSnapshot } from '../core/models.js';
 import {
   listMetricSnapshots,
@@ -23,6 +27,7 @@ import {
   saveMetricSnapshot,
 } from '../snapshot-store/index.js';
 import { compareSnapshots, summarizeDrift } from '../drift-analysis/index.js';
+import { readConformanceSnapshot } from '../conformance-adapter/conformance-adapter.js';
 import {
   DriftSignal,
   GovernanceDependency,
@@ -53,9 +58,12 @@ import {
 import { AiAnalysisRequest, AiAnalysisResult } from '../core/models.js';
 import { execFileSync } from 'node:child_process';
 import { exportAiHandoffArtifacts } from '../ai-handoff/index.js';
+import { resolveConformanceInput } from './resolve-conformance-input.js';
 import {
+  buildConformanceSignals,
   buildGraphSignals,
   buildPolicySignals,
+  mergeGovernanceSignals,
 } from '../signal-engine/index.js';
 import { WorkspaceGraphSnapshot } from '../nx-adapter/graph-adapter.js';
 
@@ -63,6 +71,7 @@ export interface GovernanceRunOptions {
   profile?: string;
   output?: 'cli' | 'json';
   failOnViolation?: boolean;
+  conformanceJson?: string;
   reportType?: 'health' | 'boundaries' | 'ownership' | 'architecture';
 }
 
@@ -1436,14 +1445,25 @@ async function buildAssessment(
   const snapshot = await readNxWorkspaceSnapshot();
   const inventory = buildInventory(snapshot, overrides);
   const allViolations = evaluatePolicies(inventory, effectiveProfile);
-  const metricSignals = [
-    ...buildGraphSignals(toWorkspaceGraphSnapshot(inventory)),
-    ...buildPolicySignals(allViolations),
-  ];
+  const graphSignals = buildGraphSignals(toWorkspaceGraphSnapshot(inventory));
+  const policySignals = buildPolicySignals(allViolations);
+  const resolvedConformanceInput = resolveConformanceInput(
+    options.conformanceJson
+  );
+  const conformanceSignals = loadConformanceSignals(resolvedConformanceInput);
+  const metricSignals = mergeGovernanceSignals(
+    graphSignals,
+    conformanceSignals,
+    policySignals
+  );
   const allMeasurements = calculateMetrics({
     workspace: inventory,
     signals: metricSignals,
   });
+  const filteredSignals = filterSignalsForReportType(
+    metricSignals,
+    options.reportType
+  );
 
   return {
     workspace: inventory,
@@ -1451,6 +1471,7 @@ async function buildAssessment(
     warnings: overrides.runtimeWarnings,
     violations: filterViolations(allViolations, options.reportType),
     measurements: filterMeasurements(allMeasurements, options.reportType),
+    signalBreakdown: buildSignalBreakdown(filteredSignals),
     health: calculateHealthScore(
       allMeasurements,
       metricWeightsFromProfile(effectiveProfile.metrics)
@@ -1558,6 +1579,30 @@ function filterMeasurements(
   return measurements;
 }
 
+function loadConformanceSignals(
+  input: ReturnType<typeof resolveConformanceInput>
+) {
+  if (!input.conformanceJson) {
+    return [];
+  }
+
+  try {
+    return buildConformanceSignals(
+      readConformanceSnapshot({ conformanceJson: input.conformanceJson })
+    );
+  } catch (error) {
+    if (input.source === 'nx-json') {
+      throw new Error(
+        `Unable to load Nx Conformance output configured in nx.json at "${
+          input.conformanceJson
+        }": ${toErrorMessage(error)}`
+      );
+    }
+
+    throw error;
+  }
+}
+
 function resolveSnapshotPath(
   explicitPath: string | undefined,
   fallbackPath: string | undefined
@@ -1569,6 +1614,10 @@ function resolveSnapshotPath(
   return path.isAbsolute(explicitPath)
     ? explicitPath
     : path.resolve(workspaceRoot, explicitPath);
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Unknown error.';
 }
 
 function renderDriftCliReport(

--- a/packages/governance/src/reporting/render-cli.ts
+++ b/packages/governance/src/reporting/render-cli.ts
@@ -5,10 +5,18 @@ export function renderCliReport(assessment: GovernanceAssessment): string {
 
   lines.push(`Nx Governance - ${assessment.profile}`);
   lines.push('');
-  lines.push(`Health Score: ${assessment.health.score} (${assessment.health.grade})`);
+  lines.push(
+    `Health Score: ${assessment.health.score} (${assessment.health.grade})`
+  );
   lines.push(`Projects: ${assessment.workspace.projects.length}`);
   lines.push(`Dependencies: ${assessment.workspace.dependencies.length}`);
   lines.push(`Violations: ${assessment.violations.length}`);
+
+  lines.push('');
+  lines.push('Signal Sources:');
+  for (const entry of assessment.signalBreakdown.bySource) {
+    lines.push(`- ${entry.source}: ${entry.count}`);
+  }
 
   if (assessment.warnings.length > 0) {
     lines.push('');
@@ -29,7 +37,9 @@ export function renderCliReport(assessment: GovernanceAssessment): string {
     lines.push('');
     lines.push('Top Violations:');
     for (const violation of assessment.violations.slice(0, 10)) {
-      lines.push(`- [${violation.severity}] ${violation.ruleId} :: ${violation.message}`);
+      lines.push(
+        `- [${violation.severity}] ${violation.ruleId} :: ${violation.message}`
+      );
     }
   }
 

--- a/packages/governance/src/reporting/rendering.spec.ts
+++ b/packages/governance/src/reporting/rendering.spec.ts
@@ -1,0 +1,72 @@
+import type { GovernanceAssessment } from '../core/index.js';
+
+import { renderCliReport } from './render-cli.js';
+import { renderJsonReport } from './render-json.js';
+
+describe('governance report rendering', () => {
+  it('renders deterministic signal source rows in CLI output', () => {
+    const rendered = renderCliReport(makeAssessment());
+
+    expect(rendered).toContain('Signal Sources:');
+    expect(rendered).toContain('- graph: 3');
+    expect(rendered).toContain('- conformance: 1');
+    expect(rendered).toContain('- policy: 2');
+    expect(rendered.indexOf('Signal Sources:')).toBeLessThan(
+      rendered.indexOf('Metrics:')
+    );
+  });
+
+  it('includes signal breakdown in JSON output', () => {
+    const rendered = renderJsonReport(makeAssessment());
+
+    expect(JSON.parse(rendered)).toMatchObject({
+      signalBreakdown: {
+        total: 6,
+        bySource: [
+          { source: 'graph', count: 3 },
+          { source: 'conformance', count: 1 },
+          { source: 'policy', count: 2 },
+        ],
+      },
+    });
+  });
+});
+
+function makeAssessment(): GovernanceAssessment {
+  return {
+    workspace: {
+      id: 'workspace',
+      name: 'workspace',
+      root: '/workspace',
+      projects: [],
+      dependencies: [],
+    },
+    profile: 'angular-cleanup',
+    warnings: [],
+    violations: [],
+    measurements: [
+      {
+        id: 'architectural-entropy',
+        name: 'Architectural Entropy',
+        value: 0.2,
+        score: 80,
+        maxScore: 100,
+        unit: 'ratio',
+      },
+    ],
+    signalBreakdown: {
+      total: 6,
+      bySource: [
+        { source: 'graph', count: 3 },
+        { source: 'conformance', count: 1 },
+        { source: 'policy', count: 2 },
+      ],
+    },
+    health: {
+      score: 80,
+      grade: 'B',
+      hotspots: [],
+    },
+    recommendations: [],
+  };
+}

--- a/packages/governance/src/reporting/signal-breakdown.spec.ts
+++ b/packages/governance/src/reporting/signal-breakdown.spec.ts
@@ -1,0 +1,129 @@
+import type { GovernanceSignal } from '../signal-engine/index.js';
+
+import {
+  buildSignalBreakdown,
+  filterSignalsForReportType,
+} from './signal-breakdown.js';
+
+describe('signal breakdown helpers', () => {
+  it('returns source counts in fixed order independent of input order', () => {
+    const signals = [
+      makeSignal({
+        id: 'policy-boundary',
+        source: 'policy',
+        type: 'domain-boundary-violation',
+        category: 'boundary',
+      }),
+      makeSignal({
+        id: 'conformance-boundary',
+        source: 'conformance',
+        type: 'conformance-violation',
+        category: 'boundary',
+      }),
+      makeSignal({
+        id: 'graph-structural',
+        source: 'graph',
+        type: 'structural-dependency',
+        category: 'dependency',
+      }),
+      makeSignal({
+        id: 'graph-domain',
+        source: 'graph',
+        type: 'cross-domain-dependency',
+        category: 'boundary',
+      }),
+    ];
+
+    expect(buildSignalBreakdown(signals)).toEqual(
+      buildSignalBreakdown([...signals].reverse())
+    );
+    expect(buildSignalBreakdown(signals)).toEqual({
+      total: 4,
+      bySource: [
+        { source: 'graph', count: 2 },
+        { source: 'conformance', count: 1 },
+        { source: 'policy', count: 1 },
+      ],
+    });
+  });
+
+  it('includes zero-count buckets for absent sources', () => {
+    expect(
+      buildSignalBreakdown([
+        makeSignal({
+          id: 'graph-only',
+          source: 'graph',
+          type: 'structural-dependency',
+          category: 'dependency',
+        }),
+      ])
+    ).toEqual({
+      total: 1,
+      bySource: [
+        { source: 'graph', count: 1 },
+        { source: 'conformance', count: 0 },
+        { source: 'policy', count: 0 },
+      ],
+    });
+  });
+
+  it('filters signal sets by report type before breakdown', () => {
+    const signals = [
+      makeSignal({
+        id: 'graph-structural',
+        source: 'graph',
+        type: 'structural-dependency',
+        category: 'dependency',
+      }),
+      makeSignal({
+        id: 'graph-boundary',
+        source: 'graph',
+        type: 'cross-domain-dependency',
+        category: 'boundary',
+      }),
+      makeSignal({
+        id: 'conformance-ownership',
+        source: 'conformance',
+        type: 'conformance-violation',
+        category: 'ownership',
+      }),
+      makeSignal({
+        id: 'policy-ownership',
+        source: 'policy',
+        type: 'ownership-gap',
+        category: 'ownership',
+      }),
+    ];
+
+    expect(
+      filterSignalsForReportType(signals, 'boundaries').map((s) => s.id)
+    ).toEqual(['graph-boundary']);
+    expect(
+      filterSignalsForReportType(signals, 'ownership').map((s) => s.id)
+    ).toEqual(['conformance-ownership', 'policy-ownership']);
+    expect(
+      filterSignalsForReportType(signals, 'architecture').map((s) => s.id)
+    ).toEqual(['graph-structural', 'graph-boundary']);
+    expect(
+      filterSignalsForReportType(signals, 'health').map((s) => s.id)
+    ).toEqual(signals.map((signal) => signal.id));
+  });
+});
+
+function makeSignal(
+  overrides: Partial<GovernanceSignal> & Pick<GovernanceSignal, 'id'>
+): GovernanceSignal {
+  return {
+    id: overrides.id,
+    type: overrides.type ?? 'conformance-violation',
+    sourceProjectId: overrides.sourceProjectId,
+    targetProjectId: overrides.targetProjectId,
+    relatedProjectIds: overrides.relatedProjectIds ?? [],
+    severity: overrides.severity ?? 'warning',
+    category: overrides.category ?? 'boundary',
+    message: overrides.message ?? overrides.id,
+    metadata: overrides.metadata,
+    source: overrides.source ?? 'graph',
+    createdAt: overrides.createdAt ?? '2026-03-30T00:00:00.000Z',
+  };
+}

--- a/packages/governance/src/reporting/signal-breakdown.ts
+++ b/packages/governance/src/reporting/signal-breakdown.ts
@@ -1,0 +1,47 @@
+import type { SignalBreakdown } from '../core/index.js';
+import type { GovernanceSignal } from '../signal-engine/index.js';
+
+export type GovernanceReportType =
+  | 'health'
+  | 'boundaries'
+  | 'ownership'
+  | 'architecture';
+
+const SOURCE_ORDER = ['graph', 'conformance', 'policy'] as const;
+
+export function filterSignalsForReportType(
+  signals: GovernanceSignal[],
+  reportType: GovernanceReportType | undefined
+): GovernanceSignal[] {
+  if (reportType === 'boundaries') {
+    return signals.filter((signal) => signal.category === 'boundary');
+  }
+
+  if (reportType === 'ownership') {
+    return signals.filter((signal) => signal.category === 'ownership');
+  }
+
+  if (reportType === 'architecture') {
+    return signals.filter((signal) => signal.category !== 'ownership');
+  }
+
+  return signals;
+}
+
+export function buildSignalBreakdown(
+  signals: GovernanceSignal[]
+): SignalBreakdown {
+  const counts = new Map<string, number>();
+
+  for (const signal of signals) {
+    counts.set(signal.source, (counts.get(signal.source) ?? 0) + 1);
+  }
+
+  return {
+    total: signals.length,
+    bySource: SOURCE_ORDER.map((source) => ({
+      source,
+      count: counts.get(source) ?? 0,
+    })),
+  };
+}

--- a/packages/governance/src/signal-engine/builders.ts
+++ b/packages/governance/src/signal-engine/builders.ts
@@ -140,19 +140,10 @@ export function buildConformanceSignals(
 export function buildGovernanceSignals(
   options: BuildGovernanceSignalsOptions
 ): GovernanceSignal[] {
-  const mergedSignals = [
-    ...buildGraphSignals(options.graphSnapshot),
-    ...buildConformanceSignals(options.conformanceSnapshot),
-  ];
-  const dedupedSignals = new Map<string, GovernanceSignal>();
-
-  for (const signal of mergedSignals) {
-    if (!dedupedSignals.has(signal.id)) {
-      dedupedSignals.set(signal.id, signal);
-    }
-  }
-
-  return [...dedupedSignals.values()].sort(compareSignals);
+  return mergeGovernanceSignals(
+    buildGraphSignals(options.graphSnapshot),
+    buildConformanceSignals(options.conformanceSnapshot)
+  );
 }
 
 export interface BuildPolicySignalsOptions {
@@ -168,6 +159,20 @@ export function buildPolicySignals(
   return violations
     .flatMap((violation) => mapViolationToPolicySignal(violation, createdAt))
     .sort(compareSignals);
+}
+
+export function mergeGovernanceSignals(
+  ...signalGroups: GovernanceSignal[][]
+): GovernanceSignal[] {
+  const dedupedSignals = new Map<string, GovernanceSignal>();
+
+  for (const signal of signalGroups.flat()) {
+    if (!dedupedSignals.has(signal.id)) {
+      dedupedSignals.set(signal.id, signal);
+    }
+  }
+
+  return [...dedupedSignals.values()].sort(compareSignals);
 }
 
 function mapConformanceFindingToSignal(

--- a/packages/governance/src/signal-engine/index.ts
+++ b/packages/governance/src/signal-engine/index.ts
@@ -9,5 +9,6 @@ export {
   buildConformanceSignals,
   buildGovernanceSignals,
   buildGraphSignals,
+  mergeGovernanceSignals,
   buildPolicySignals,
 } from './builders.js';

--- a/packages/governance/src/snapshot-store/index.spec.ts
+++ b/packages/governance/src/snapshot-store/index.spec.ts
@@ -49,6 +49,14 @@ describe('snapshot-store', () => {
           unit: 'ratio',
         },
       ],
+      signalBreakdown: {
+        total: 0,
+        bySource: [
+          { source: 'graph', count: 0 },
+          { source: 'conformance', count: 0 },
+          { source: 'policy', count: 0 },
+        ],
+      },
       health: {
         score: 80,
         grade: 'B',


### PR DESCRIPTION
Extend nx-governance reporting to expose deterministic signal source breakdowns and merge Nx Conformance findings into the canonical governance signal pipeline.

- add graph/conformance/policy source breakdown to CLI and JSON output
- wire optional conformance signals into metrics and health scoring
- support conformanceJson override with nx.json outputPath fallback
- add regression coverage for source reporting and conformance resolution
- update README and roadmap for source-aware reporting

Closes #46 Refs #36