### PR TITLE
feat(governance): add signal type and severity breakdowns

### DIFF
--- a/packages/governance/README.md
+++ b/packages/governance/README.md
@@ -322,7 +322,7 @@ nx repo-health --failOnViolation
 
 **Metrics included:** all six (Architectural Entropy, Dependency Complexity, Domain Integrity, Ownership Coverage, Documentation Completeness, Layer Integrity).
 
-**Signal sources shown:** graph, conformance, and policy. The CLI report prints a deterministic `Signal Sources` section, and the JSON output includes `signalBreakdown.total` plus `signalBreakdown.bySource`.
+**Signal breakdown shown:** graph, conformance, and policy source counts, plus per-type and per-severity counts. The CLI report prints deterministic `Signal Sources`, `Signal Types`, and `Signal Severity` sections, and the JSON output includes `signalBreakdown.total`, `signalBreakdown.bySource`, `signalBreakdown.byType`, and `signalBreakdown.bySeverity`.
 
 **Conformance input resolution:** explicit `--conformanceJson` wins. If it is not provided, governance tries `nx.json > conformance.outputPath`. If neither is available, the report still renders with a `conformance` count of `0`. If `nx.json` declares an output path but the file cannot be read, governance fails with a clear configuration error.
 
@@ -341,7 +341,7 @@ nx repo-boundaries --output=json --failOnViolation
 
 **Metrics included:** Architectural Entropy, Domain Integrity, Layer Integrity.
 
-**Signal sources shown:** boundary-scoped graph, conformance, and policy signals only.
+**Signal breakdown shown:** boundary-scoped source, type, and severity counts only.
 
 **Violations surfaced:**
 
@@ -363,7 +363,7 @@ nx repo-ownership --output=json
 
 **Metrics included:** Ownership Coverage.
 
-**Signal sources shown:** ownership-scoped graph, conformance, and policy signals only.
+**Signal breakdown shown:** ownership-scoped source, type, and severity counts only.
 
 **Violations surfaced:**
 
@@ -384,21 +384,27 @@ nx repo-architecture --output=json
 
 **Metrics included:** Architectural Entropy, Dependency Complexity, Domain Integrity.
 
-**Signal sources shown:** all non-ownership graph, conformance, and policy signals.
+**Signal breakdown shown:** all non-ownership source, type, and severity counts.
 
 **Violations surfaced:** all violation types _except_ `ownership-presence`.
 
 **Use when:** you want to track architectural drift over time and are not concerned with team assignment in this particular run.
 
-### Signal Source Breakdown
+### Signal Breakdown
 
-When governance reporting is rendered, the assessment always includes a source breakdown with fixed rows in this order:
+When governance reporting is rendered, the assessment always includes a signal breakdown with these views:
 
-- `graph`
-- `conformance`
-- `policy`
+- `bySource` with fixed rows in this order:
+  - `graph`
+  - `conformance`
+  - `policy`
+- `byType` with observed signal types only, in canonical governance signal order
+- `bySeverity` with fixed rows in this order:
+  - `info`
+  - `warning`
+  - `error`
 
-Counts are scoped to the active report type. For example, `repo-boundaries` only counts boundary-category signals, while `repo-architecture` excludes ownership-category signals. If `conformanceJson` is omitted, the `conformance` row is still present with count `0`.
+Counts are scoped to the active report type. For example, `repo-boundaries` only counts boundary-category signals, while `repo-architecture` excludes ownership-category signals. If `conformanceJson` is omitted, the `conformance` row is still present with count `0`. Severity rows are always present even when their count is `0`, while type rows are observed-only.
 
 ---
 

--- a/packages/governance/ROADMAP.md
+++ b/packages/governance/ROADMAP.md
@@ -47,6 +47,8 @@ Goal:
   - [x] Graph findings
   - [x] Conformance findings
 - [x] Add counts per source
+- [x] Add counts per signal type
+- [x] Add severity grouping for signals
 
 ---
 

--- a/packages/governance/src/core/models.ts
+++ b/packages/governance/src/core/models.ts
@@ -1,3 +1,8 @@
+import type {
+  GovernanceSignalSeverity,
+  GovernanceSignalType,
+} from '../signal-engine/types.js';
+
 export interface GovernanceWorkspace {
   id: string;
   name: string;
@@ -68,9 +73,21 @@ export interface SignalBreakdownEntry {
   count: number;
 }
 
+export interface SignalTypeBreakdownEntry {
+  type: GovernanceSignalType;
+  count: number;
+}
+
+export interface SignalSeverityBreakdownEntry {
+  severity: GovernanceSignalSeverity;
+  count: number;
+}
+
 export interface SignalBreakdown {
   total: number;
   bySource: SignalBreakdownEntry[];
+  byType: SignalTypeBreakdownEntry[];
+  bySeverity: SignalSeverityBreakdownEntry[];
 }
 
 export interface GovernanceAssessment {

--- a/packages/governance/src/plugin/run-governance.spec.ts
+++ b/packages/governance/src/plugin/run-governance.spec.ts
@@ -81,6 +81,26 @@ describe('runGovernance', () => {
         count: health.assessment.signalBreakdown.bySource[2].count,
       },
     ]);
+    expect(health.assessment.signalBreakdown.bySeverity).toEqual([
+      {
+        severity: 'info',
+        count: health.assessment.signalBreakdown.bySeverity[0].count,
+      },
+      {
+        severity: 'warning',
+        count: health.assessment.signalBreakdown.bySeverity[1].count,
+      },
+      {
+        severity: 'error',
+        count: health.assessment.signalBreakdown.bySeverity[2].count,
+      },
+    ]);
+    expect(
+      health.assessment.signalBreakdown.byType.reduce(
+        (total, entry) => total + entry.count,
+        0
+      )
+    ).toBe(health.assessment.signalBreakdown.total);
   });
 
   it('loads conformance signals into the assessment pipeline when conformanceJson is provided', async () => {
@@ -121,6 +141,20 @@ describe('runGovernance', () => {
           (entry) => entry.source === 'conformance'
         )
       ).toEqual({ source: 'conformance', count: 1 });
+      expect(
+        withConformance.assessment.signalBreakdown.byType.find(
+          (entry) => entry.type === 'conformance-violation'
+        )
+      ).toEqual({ type: 'conformance-violation', count: 1 });
+      expect(
+        withConformance.assessment.signalBreakdown.bySeverity.find(
+          (entry) => entry.severity === 'error'
+        )?.count
+      ).toBe(
+        (baseline.assessment.signalBreakdown.bySeverity.find(
+          (entry) => entry.severity === 'error'
+        )?.count ?? 0) + 1
+      );
 
       const baselineEntropy = baseline.assessment.measurements.find(
         (metric) => metric.id === 'architectural-entropy'
@@ -266,5 +300,71 @@ describe('runGovernance', () => {
     await expect(runGovernance({ reportType: 'health' })).rejects.toThrow(
       'Unable to load Nx Conformance output configured in nx.json'
     );
+  });
+
+  it('filters type and severity breakdowns to the active report type', async () => {
+    jest.spyOn(logger, 'info').mockImplementation(() => undefined);
+
+    const tempDir = mkdtempSync(
+      path.join(tmpdir(), 'nx-governance-conformance-')
+    );
+    const conformanceJson = path.join(tempDir, 'conformance.json');
+
+    writeFileSync(
+      conformanceJson,
+      JSON.stringify([
+        {
+          id: 'finding-boundary',
+          ruleId: '@nx/conformance/enforce-project-boundaries',
+          severity: 'error',
+          message: 'Conformance boundary violation',
+          projectId: 'packages/governance',
+        },
+        {
+          id: 'finding-ownership',
+          ruleId: '@nx/conformance/ensure-owners',
+          severity: 'warning',
+          message: 'Conformance ownership warning',
+          projectId: 'packages/governance',
+        },
+      ])
+    );
+
+    try {
+      const boundaries = await runGovernance({
+        reportType: 'boundaries',
+        conformanceJson,
+      });
+      const ownership = await runGovernance({
+        reportType: 'ownership',
+        conformanceJson,
+      });
+
+      expect(boundaries.assessment.signalBreakdown.byType).toContainEqual({
+        type: 'conformance-violation',
+        count: 1,
+      });
+      expect(
+        boundaries.assessment.signalBreakdown.bySeverity.find(
+          (entry) => entry.severity === 'error'
+        )?.count
+      ).toBeGreaterThanOrEqual(1);
+
+      expect(ownership.assessment.signalBreakdown.bySource).toEqual([
+        { source: 'graph', count: 0 },
+        { source: 'conformance', count: 1 },
+        { source: 'policy', count: 0 },
+      ]);
+      expect(ownership.assessment.signalBreakdown.byType).toEqual([
+        { type: 'conformance-violation', count: 1 },
+      ]);
+      expect(ownership.assessment.signalBreakdown.bySeverity).toEqual([
+        { severity: 'info', count: 0 },
+        { severity: 'warning', count: 1 },
+        { severity: 'error', count: 0 },
+      ]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/governance/src/reporting/render-cli.ts
+++ b/packages/governance/src/reporting/render-cli.ts
@@ -18,6 +18,18 @@ export function renderCliReport(assessment: GovernanceAssessment): string {
     lines.push(`- ${entry.source}: ${entry.count}`);
   }
 
+  lines.push('');
+  lines.push('Signal Types:');
+  for (const entry of assessment.signalBreakdown.byType) {
+    lines.push(`- ${entry.type}: ${entry.count}`);
+  }
+
+  lines.push('');
+  lines.push('Signal Severity:');
+  for (const entry of assessment.signalBreakdown.bySeverity) {
+    lines.push(`- ${entry.severity}: ${entry.count}`);
+  }
+
   if (assessment.warnings.length > 0) {
     lines.push('');
     lines.push('Warnings:');

--- a/packages/governance/src/reporting/rendering.spec.ts
+++ b/packages/governance/src/reporting/rendering.spec.ts
@@ -8,10 +8,23 @@ describe('governance report rendering', () => {
     const rendered = renderCliReport(makeAssessment());
 
     expect(rendered).toContain('Signal Sources:');
+    expect(rendered).toContain('Signal Types:');
+    expect(rendered).toContain('Signal Severity:');
     expect(rendered).toContain('- graph: 3');
     expect(rendered).toContain('- conformance: 1');
     expect(rendered).toContain('- policy: 2');
+    expect(rendered).toContain('- structural-dependency: 2');
+    expect(rendered).toContain('- conformance-violation: 1');
+    expect(rendered).toContain('- info: 2');
+    expect(rendered).toContain('- warning: 3');
+    expect(rendered).toContain('- error: 1');
     expect(rendered.indexOf('Signal Sources:')).toBeLessThan(
+      rendered.indexOf('Signal Types:')
+    );
+    expect(rendered.indexOf('Signal Types:')).toBeLessThan(
+      rendered.indexOf('Signal Severity:')
+    );
+    expect(rendered.indexOf('Signal Severity:')).toBeLessThan(
       rendered.indexOf('Metrics:')
     );
   });
@@ -26,6 +39,17 @@ describe('governance report rendering', () => {
           { source: 'graph', count: 3 },
           { source: 'conformance', count: 1 },
           { source: 'policy', count: 2 },
+        ],
+        byType: [
+          { type: 'structural-dependency', count: 2 },
+          { type: 'conformance-violation', count: 1 },
+          { type: 'domain-boundary-violation', count: 2 },
+          { type: 'ownership-gap', count: 1 },
+        ],
+        bySeverity: [
+          { severity: 'info', count: 2 },
+          { severity: 'warning', count: 3 },
+          { severity: 'error', count: 1 },
         ],
       },
     });
@@ -60,6 +84,17 @@ function makeAssessment(): GovernanceAssessment {
         { source: 'graph', count: 3 },
         { source: 'conformance', count: 1 },
         { source: 'policy', count: 2 },
+      ],
+      byType: [
+        { type: 'structural-dependency', count: 2 },
+        { type: 'conformance-violation', count: 1 },
+        { type: 'domain-boundary-violation', count: 2 },
+        { type: 'ownership-gap', count: 1 },
+      ],
+      bySeverity: [
+        { severity: 'info', count: 2 },
+        { severity: 'warning', count: 3 },
+        { severity: 'error', count: 1 },
       ],
     },
     health: {

--- a/packages/governance/src/reporting/signal-breakdown.spec.ts
+++ b/packages/governance/src/reporting/signal-breakdown.spec.ts
@@ -25,6 +25,7 @@ describe('signal breakdown helpers', () => {
         source: 'graph',
         type: 'structural-dependency',
         category: 'dependency',
+        severity: 'info',
       }),
       makeSignal({
         id: 'graph-domain',
@@ -44,6 +45,17 @@ describe('signal breakdown helpers', () => {
         { source: 'conformance', count: 1 },
         { source: 'policy', count: 1 },
       ],
+      byType: [
+        { type: 'structural-dependency', count: 1 },
+        { type: 'cross-domain-dependency', count: 1 },
+        { type: 'conformance-violation', count: 1 },
+        { type: 'domain-boundary-violation', count: 1 },
+      ],
+      bySeverity: [
+        { severity: 'info', count: 1 },
+        { severity: 'warning', count: 3 },
+        { severity: 'error', count: 0 },
+      ],
     });
   });
 
@@ -55,6 +67,7 @@ describe('signal breakdown helpers', () => {
           source: 'graph',
           type: 'structural-dependency',
           category: 'dependency',
+          severity: 'info',
         }),
       ])
     ).toEqual({
@@ -64,16 +77,23 @@ describe('signal breakdown helpers', () => {
         { source: 'conformance', count: 0 },
         { source: 'policy', count: 0 },
       ],
+      byType: [{ type: 'structural-dependency', count: 1 }],
+      bySeverity: [
+        { severity: 'info', count: 1 },
+        { severity: 'warning', count: 0 },
+        { severity: 'error', count: 0 },
+      ],
     });
   });
 
-  it('filters signal sets by report type before breakdown', () => {
+  it('filters signal sets by report type before type and severity aggregation', () => {
     const signals = [
       makeSignal({
         id: 'graph-structural',
         source: 'graph',
         type: 'structural-dependency',
         category: 'dependency',
+        severity: 'info',
       }),
       makeSignal({
         id: 'graph-boundary',
@@ -107,6 +127,52 @@ describe('signal breakdown helpers', () => {
     expect(
       filterSignalsForReportType(signals, 'health').map((s) => s.id)
     ).toEqual(signals.map((signal) => signal.id));
+  });
+
+  it('keeps type ordering deterministic and observed-only', () => {
+    const breakdown = buildSignalBreakdown([
+      makeSignal({
+        id: 'policy-ownership',
+        source: 'policy',
+        type: 'ownership-gap',
+        category: 'ownership',
+      }),
+      makeSignal({
+        id: 'graph-missing-domain',
+        source: 'graph',
+        type: 'missing-domain-context',
+        category: 'boundary',
+      }),
+      makeSignal({
+        id: 'graph-structural',
+        source: 'graph',
+        type: 'structural-dependency',
+        category: 'dependency',
+        severity: 'info',
+      }),
+      makeSignal({
+        id: 'conformance-boundary',
+        source: 'conformance',
+        type: 'conformance-violation',
+        category: 'boundary',
+        severity: 'error',
+      }),
+    ]);
+
+    expect(breakdown.byType).toEqual([
+      { type: 'structural-dependency', count: 1 },
+      { type: 'missing-domain-context', count: 1 },
+      { type: 'conformance-violation', count: 1 },
+      { type: 'ownership-gap', count: 1 },
+    ]);
+    expect(
+      breakdown.byType.find((entry) => entry.type === 'circular-dependency')
+    ).toBeUndefined();
+    expect(breakdown.bySeverity).toEqual([
+      { severity: 'info', count: 1 },
+      { severity: 'warning', count: 2 },
+      { severity: 'error', count: 1 },
+    ]);
   });
 });
 

--- a/packages/governance/src/reporting/signal-breakdown.ts
+++ b/packages/governance/src/reporting/signal-breakdown.ts
@@ -1,5 +1,9 @@
 import type { SignalBreakdown } from '../core/index.js';
-import type { GovernanceSignal } from '../signal-engine/index.js';
+import type {
+  GovernanceSignal,
+  GovernanceSignalSeverity,
+  GovernanceSignalType,
+} from '../signal-engine/index.js';
 
 export type GovernanceReportType =
   | 'health'
@@ -8,6 +12,17 @@ export type GovernanceReportType =
   | 'architecture';
 
 const SOURCE_ORDER = ['graph', 'conformance', 'policy'] as const;
+const SEVERITY_ORDER: GovernanceSignalSeverity[] = ['info', 'warning', 'error'];
+const TYPE_ORDER: GovernanceSignalType[] = [
+  'structural-dependency',
+  'cross-domain-dependency',
+  'missing-domain-context',
+  'circular-dependency',
+  'conformance-violation',
+  'domain-boundary-violation',
+  'layer-boundary-violation',
+  'ownership-gap',
+];
 
 export function filterSignalsForReportType(
   signals: GovernanceSignal[],
@@ -31,17 +46,33 @@ export function filterSignalsForReportType(
 export function buildSignalBreakdown(
   signals: GovernanceSignal[]
 ): SignalBreakdown {
-  const counts = new Map<string, number>();
+  const sourceCounts = new Map<string, number>();
+  const typeCounts = new Map<GovernanceSignalType, number>();
+  const severityCounts = new Map<GovernanceSignalSeverity, number>();
 
   for (const signal of signals) {
-    counts.set(signal.source, (counts.get(signal.source) ?? 0) + 1);
+    sourceCounts.set(signal.source, (sourceCounts.get(signal.source) ?? 0) + 1);
+    typeCounts.set(signal.type, (typeCounts.get(signal.type) ?? 0) + 1);
+    severityCounts.set(
+      signal.severity,
+      (severityCounts.get(signal.severity) ?? 0) + 1
+    );
   }
 
   return {
     total: signals.length,
     bySource: SOURCE_ORDER.map((source) => ({
       source,
-      count: counts.get(source) ?? 0,
+      count: sourceCounts.get(source) ?? 0,
+    })),
+    byType: TYPE_ORDER.flatMap((type) => {
+      const count = typeCounts.get(type) ?? 0;
+
+      return count > 0 ? [{ type, count }] : [];
+    }),
+    bySeverity: SEVERITY_ORDER.map((severity) => ({
+      severity,
+      count: severityCounts.get(severity) ?? 0,
     })),
   };
 }

--- a/packages/governance/src/snapshot-store/index.spec.ts
+++ b/packages/governance/src/snapshot-store/index.spec.ts
@@ -56,6 +56,12 @@ describe('snapshot-store', () => {
           { source: 'conformance', count: 0 },
           { source: 'policy', count: 0 },
         ],
+        byType: [],
+        bySeverity: [
+          { severity: 'info', count: 0 },
+          { severity: 'warning', count: 0 },
+          { severity: 'error', count: 0 },
+        ],
       },
       health: {
         score: 80,


### PR DESCRIPTION
Extend nx-governance reporting to expose deterministic per-signal-type and per-severity counts in both CLI and JSON output.

- add byType and bySeverity to signalBreakdown
- render Signal Types and Signal Severity sections in CLI output
- keep report-type filtering semantics unchanged
- add regression coverage for breakdown ordering and conformance cases
- update README and roadmap for richer explainability output

Closes #47 Refs #36