### PR TITLE
feat(governance): add metric families and unified top issues

### DIFF
--- a/packages/governance/README.md
+++ b/packages/governance/README.md
@@ -324,6 +324,8 @@ nx repo-health --failOnViolation
 
 **Signal breakdown shown:** graph, conformance, and policy source counts, plus per-type and per-severity counts. The CLI report prints deterministic `Signal Sources`, `Signal Types`, and `Signal Severity` sections, and the JSON output includes `signalBreakdown.total`, `signalBreakdown.bySource`, `signalBreakdown.byType`, and `signalBreakdown.bySeverity`.
 
+**Metric and issue breakdown shown:** the CLI also prints `Metric Families` and `Top Issues`, and the JSON output includes `metricBreakdown.families` plus `topIssues`.
+
 **Conformance input resolution:** explicit `--conformanceJson` wins. If it is not provided, governance tries `nx.json > conformance.outputPath`. If neither is available, the report still renders with a `conformance` count of `0`. If `nx.json` declares an output path but the file cannot be read, governance fails with a clear configuration error.
 
 **Use when:** you want a single number that summarises overall workspace quality, or when running a health gate in CI.
@@ -405,6 +407,15 @@ When governance reporting is rendered, the assessment always includes a signal b
   - `error`
 
 Counts are scoped to the active report type. For example, `repo-boundaries` only counts boundary-category signals, while `repo-architecture` excludes ownership-category signals. If `conformanceJson` is omitted, the `conformance` row is still present with count `0`. Severity rows are always present even when their count is `0`, while type rows are observed-only.
+
+### Metric Families and Top Issues
+
+Governance reporting also publishes:
+
+- `metricBreakdown.families` with deterministic family ordering: `architecture`, `boundaries`, `ownership`, `documentation`
+- `topIssues`, a unified ranked list built from filtered governance signals rather than policy violations alone
+
+`Top Issues` is ordered by severity first, then issue frequency, then canonical signal ordering. Policy-backed issues include `ruleId` when available.
 
 ---
 

--- a/packages/governance/src/core/models.ts
+++ b/packages/governance/src/core/models.ts
@@ -1,5 +1,6 @@
 import type {
   GovernanceSignalSeverity,
+  GovernanceSignalSource,
   GovernanceSignalType,
 } from '../signal-engine/types.js';
 
@@ -90,6 +91,38 @@ export interface SignalBreakdown {
   bySeverity: SignalSeverityBreakdownEntry[];
 }
 
+export type GovernanceMetricFamily =
+  | 'architecture'
+  | 'boundaries'
+  | 'ownership'
+  | 'documentation';
+
+export interface MetricBreakdownMeasurement {
+  id: Measurement['id'];
+  name: string;
+  score: number;
+}
+
+export interface MetricBreakdownFamily {
+  family: GovernanceMetricFamily;
+  score: number;
+  measurements: MetricBreakdownMeasurement[];
+}
+
+export interface MetricBreakdown {
+  families: MetricBreakdownFamily[];
+}
+
+export interface GovernanceTopIssue {
+  type: GovernanceSignalType;
+  source: GovernanceSignalSource;
+  severity: GovernanceSignalSeverity;
+  count: number;
+  projects: string[];
+  ruleId?: string;
+  message: string;
+}
+
 export interface GovernanceAssessment {
   workspace: GovernanceWorkspace;
   profile: string;
@@ -97,6 +130,8 @@ export interface GovernanceAssessment {
   violations: Violation[];
   measurements: Measurement[];
   signalBreakdown: SignalBreakdown;
+  metricBreakdown: MetricBreakdown;
+  topIssues: GovernanceTopIssue[];
   health: HealthScore;
   recommendations: Recommendation[];
 }

--- a/packages/governance/src/plugin/run-governance.spec.ts
+++ b/packages/governance/src/plugin/run-governance.spec.ts
@@ -101,6 +101,18 @@ describe('runGovernance', () => {
         0
       )
     ).toBe(health.assessment.signalBreakdown.total);
+    expect(
+      health.assessment.metricBreakdown.families.map((entry) => entry.family)
+    ).toEqual(['architecture', 'boundaries', 'ownership', 'documentation']);
+    expect(
+      boundaries.assessment.metricBreakdown.families.map(
+        (entry) => entry.family
+      )
+    ).toEqual(['architecture', 'boundaries']);
+    expect(
+      ownership.assessment.metricBreakdown.families.map((entry) => entry.family)
+    ).toEqual(['ownership']);
+    expect(health.assessment.topIssues.length).toBeGreaterThan(0);
   });
 
   it('loads conformance signals into the assessment pipeline when conformanceJson is provided', async () => {
@@ -154,6 +166,14 @@ describe('runGovernance', () => {
         (baseline.assessment.signalBreakdown.bySeverity.find(
           (entry) => entry.severity === 'error'
         )?.count ?? 0) + 1
+      );
+      expect(withConformance.assessment.topIssues).toContainEqual(
+        expect.objectContaining({
+          type: 'conformance-violation',
+          source: 'conformance',
+          severity: 'error',
+          count: 1,
+        })
       );
 
       const baselineEntropy = baseline.assessment.measurements.find(
@@ -362,6 +382,22 @@ describe('runGovernance', () => {
         { severity: 'info', count: 0 },
         { severity: 'warning', count: 1 },
         { severity: 'error', count: 0 },
+      ]);
+      expect(boundaries.assessment.topIssues).toContainEqual(
+        expect.objectContaining({
+          type: 'conformance-violation',
+          source: 'conformance',
+          severity: 'error',
+          count: 1,
+        })
+      );
+      expect(ownership.assessment.topIssues).toEqual([
+        expect.objectContaining({
+          type: 'conformance-violation',
+          source: 'conformance',
+          severity: 'warning',
+          count: 1,
+        }),
       ]);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });

--- a/packages/governance/src/plugin/run-governance.ts
+++ b/packages/governance/src/plugin/run-governance.ts
@@ -16,10 +16,12 @@ import {
 } from '../presets/angular-cleanup/profile.js';
 import { renderCliReport } from '../reporting/render-cli.js';
 import { renderJsonReport } from '../reporting/render-json.js';
+import { buildMetricBreakdown } from '../reporting/metric-breakdown.js';
 import {
   buildSignalBreakdown,
   filterSignalsForReportType,
 } from '../reporting/signal-breakdown.js';
+import { buildTopIssues } from '../reporting/top-issues.js';
 import { MetricSnapshot } from '../core/models.js';
 import {
   listMetricSnapshots,
@@ -1460,8 +1462,16 @@ async function buildAssessment(
     workspace: inventory,
     signals: metricSignals,
   });
+  const filteredMeasurements = filterMeasurements(
+    allMeasurements,
+    options.reportType
+  );
   const filteredSignals = filterSignalsForReportType(
     metricSignals,
+    options.reportType
+  );
+  const filteredViolations = filterViolations(
+    allViolations,
     options.reportType
   );
 
@@ -1469,9 +1479,11 @@ async function buildAssessment(
     workspace: inventory,
     profile: profileName,
     warnings: overrides.runtimeWarnings,
-    violations: filterViolations(allViolations, options.reportType),
-    measurements: filterMeasurements(allMeasurements, options.reportType),
+    violations: filteredViolations,
+    measurements: filteredMeasurements,
     signalBreakdown: buildSignalBreakdown(filteredSignals),
+    metricBreakdown: buildMetricBreakdown(filteredMeasurements),
+    topIssues: buildTopIssues(filteredSignals),
     health: calculateHealthScore(
       allMeasurements,
       metricWeightsFromProfile(effectiveProfile.metrics)

--- a/packages/governance/src/reporting/metric-breakdown.spec.ts
+++ b/packages/governance/src/reporting/metric-breakdown.spec.ts
@@ -1,0 +1,113 @@
+import type { Measurement } from '../core/index.js';
+
+import { buildMetricBreakdown } from './metric-breakdown.js';
+
+describe('metric breakdown helpers', () => {
+  it('builds deterministic family groupings from filtered measurements', () => {
+    const breakdown = buildMetricBreakdown([
+      measurement('dependency-complexity', 'Dependency Complexity', 89),
+      measurement('architectural-entropy', 'Architectural Entropy', 66),
+      measurement('domain-integrity', 'Domain Integrity', 100),
+      measurement('layer-integrity', 'Layer Integrity', 78),
+      measurement('ownership-coverage', 'Ownership Coverage', 67),
+      measurement(
+        'documentation-completeness',
+        'Documentation Completeness',
+        33
+      ),
+    ]);
+
+    expect(breakdown.families).toEqual([
+      {
+        family: 'architecture',
+        score: 83,
+        measurements: [
+          measurementSummary(
+            'architectural-entropy',
+            'Architectural Entropy',
+            66
+          ),
+          measurementSummary(
+            'dependency-complexity',
+            'Dependency Complexity',
+            89
+          ),
+          measurementSummary('domain-integrity', 'Domain Integrity', 100),
+          measurementSummary('layer-integrity', 'Layer Integrity', 78),
+        ],
+      },
+      {
+        family: 'boundaries',
+        score: 81,
+        measurements: [
+          measurementSummary(
+            'architectural-entropy',
+            'Architectural Entropy',
+            66
+          ),
+          measurementSummary('domain-integrity', 'Domain Integrity', 100),
+          measurementSummary('layer-integrity', 'Layer Integrity', 78),
+        ],
+      },
+      {
+        family: 'ownership',
+        score: 67,
+        measurements: [
+          measurementSummary('ownership-coverage', 'Ownership Coverage', 67),
+        ],
+      },
+      {
+        family: 'documentation',
+        score: 33,
+        measurements: [
+          measurementSummary(
+            'documentation-completeness',
+            'Documentation Completeness',
+            33
+          ),
+        ],
+      },
+    ]);
+  });
+
+  it('omits empty families after report filtering', () => {
+    expect(
+      buildMetricBreakdown([
+        measurement('ownership-coverage', 'Ownership Coverage', 67),
+      ])
+    ).toEqual({
+      families: [
+        {
+          family: 'ownership',
+          score: 67,
+          measurements: [
+            measurementSummary('ownership-coverage', 'Ownership Coverage', 67),
+          ],
+        },
+      ],
+    });
+  });
+});
+
+function measurement(
+  id: Measurement['id'],
+  name: string,
+  score: number
+): Measurement {
+  return {
+    id,
+    name,
+    value: score / 100,
+    score,
+    maxScore: 100,
+    unit: 'ratio',
+  };
+}
+
+function measurementSummary(
+  id: Measurement['id'],
+  name: string,
+  score: number
+) {
+  return { id, name, score };
+}

--- a/packages/governance/src/reporting/metric-breakdown.ts
+++ b/packages/governance/src/reporting/metric-breakdown.ts
@@ -1,0 +1,66 @@
+import type {
+  GovernanceMetricFamily,
+  Measurement,
+  MetricBreakdown,
+} from '../core/index.js';
+
+const FAMILY_ORDER: GovernanceMetricFamily[] = [
+  'architecture',
+  'boundaries',
+  'ownership',
+  'documentation',
+];
+
+const FAMILY_MEASUREMENT_IDS: Record<
+  GovernanceMetricFamily,
+  Measurement['id'][]
+> = {
+  architecture: [
+    'architectural-entropy',
+    'dependency-complexity',
+    'domain-integrity',
+    'layer-integrity',
+  ],
+  boundaries: ['architectural-entropy', 'domain-integrity', 'layer-integrity'],
+  ownership: ['ownership-coverage'],
+  documentation: ['documentation-completeness'],
+};
+
+export function buildMetricBreakdown(
+  measurements: Measurement[]
+): MetricBreakdown {
+  const measurementsById = new Map(
+    measurements.map((measurement) => [measurement.id, measurement] as const)
+  );
+
+  return {
+    families: FAMILY_ORDER.flatMap((family) => {
+      const familyMeasurements = FAMILY_MEASUREMENT_IDS[family]
+        .map((id) => measurementsById.get(id))
+        .filter((measurement): measurement is Measurement => !!measurement)
+        .map((measurement) => ({
+          id: measurement.id,
+          name: measurement.name,
+          score: measurement.score,
+        }));
+
+      if (familyMeasurements.length === 0) {
+        return [];
+      }
+
+      const averageScore =
+        familyMeasurements.reduce(
+          (sum, measurement) => sum + measurement.score,
+          0
+        ) / familyMeasurements.length;
+
+      return [
+        {
+          family,
+          score: Math.round(averageScore),
+          measurements: familyMeasurements,
+        },
+      ];
+    }),
+  };
+}

--- a/packages/governance/src/reporting/render-cli.ts
+++ b/packages/governance/src/reporting/render-cli.ts
@@ -1,5 +1,7 @@
 import { GovernanceAssessment } from '../core/index.js';
 
+const TOP_ISSUES_LIMIT = 10;
+
 export function renderCliReport(assessment: GovernanceAssessment): string {
   const lines: string[] = [];
 
@@ -45,12 +47,30 @@ export function renderCliReport(assessment: GovernanceAssessment): string {
     lines.push(`- ${metric.name}: ${metric.score}/100`);
   }
 
-  if (assessment.violations.length > 0) {
+  if (assessment.metricBreakdown.families.length > 0) {
     lines.push('');
-    lines.push('Top Violations:');
-    for (const violation of assessment.violations.slice(0, 10)) {
+    lines.push('Metric Families:');
+    for (const family of assessment.metricBreakdown.families) {
+      lines.push(`- ${family.family}: ${family.score}/100`);
       lines.push(
-        `- [${violation.severity}] ${violation.ruleId} :: ${violation.message}`
+        `  measurements: ${family.measurements
+          .map((measurement) => `${measurement.name} (${measurement.score})`)
+          .join(', ')}`
+      );
+    }
+  }
+
+  if (assessment.topIssues.length > 0) {
+    lines.push('');
+    lines.push('Top Issues:');
+    for (const issue of assessment.topIssues.slice(0, TOP_ISSUES_LIMIT)) {
+      const ruleIdSuffix = issue.ruleId ? ` :: ${issue.ruleId}` : '';
+      const projectsSuffix =
+        issue.projects.length > 0
+          ? ` :: projects=${issue.projects.join(',')}`
+          : '';
+      lines.push(
+        `- [${issue.severity}] ${issue.type} (${issue.source}) x${issue.count}${ruleIdSuffix}${projectsSuffix} :: ${issue.message}`
       );
     }
   }

--- a/packages/governance/src/reporting/rendering.spec.ts
+++ b/packages/governance/src/reporting/rendering.spec.ts
@@ -10,6 +10,8 @@ describe('governance report rendering', () => {
     expect(rendered).toContain('Signal Sources:');
     expect(rendered).toContain('Signal Types:');
     expect(rendered).toContain('Signal Severity:');
+    expect(rendered).toContain('Metric Families:');
+    expect(rendered).toContain('Top Issues:');
     expect(rendered).toContain('- graph: 3');
     expect(rendered).toContain('- conformance: 1');
     expect(rendered).toContain('- policy: 2');
@@ -18,6 +20,11 @@ describe('governance report rendering', () => {
     expect(rendered).toContain('- info: 2');
     expect(rendered).toContain('- warning: 3');
     expect(rendered).toContain('- error: 1');
+    expect(rendered).toContain('- architecture: 80/100');
+    expect(rendered).toContain('- documentation: 33/100');
+    expect(rendered).toContain(
+      '- [error] domain-boundary-violation (policy) x2 :: domain-boundary :: projects=orders-app,payments-feature :: Domain boundary violation'
+    );
     expect(rendered.indexOf('Signal Sources:')).toBeLessThan(
       rendered.indexOf('Signal Types:')
     );
@@ -26,6 +33,12 @@ describe('governance report rendering', () => {
     );
     expect(rendered.indexOf('Signal Severity:')).toBeLessThan(
       rendered.indexOf('Metrics:')
+    );
+    expect(rendered.indexOf('Metrics:')).toBeLessThan(
+      rendered.indexOf('Metric Families:')
+    );
+    expect(rendered.indexOf('Metric Families:')).toBeLessThan(
+      rendered.indexOf('Top Issues:')
     );
   });
 
@@ -52,6 +65,43 @@ describe('governance report rendering', () => {
           { severity: 'error', count: 1 },
         ],
       },
+      metricBreakdown: {
+        families: [
+          {
+            family: 'architecture',
+            score: 80,
+            measurements: [
+              {
+                id: 'architectural-entropy',
+                name: 'Architectural Entropy',
+                score: 80,
+              },
+            ],
+          },
+          {
+            family: 'documentation',
+            score: 33,
+            measurements: [
+              {
+                id: 'documentation-completeness',
+                name: 'Documentation Completeness',
+                score: 33,
+              },
+            ],
+          },
+        ],
+      },
+      topIssues: [
+        {
+          type: 'domain-boundary-violation',
+          source: 'policy',
+          severity: 'error',
+          count: 2,
+          projects: ['orders-app', 'payments-feature'],
+          ruleId: 'domain-boundary',
+          message: 'Domain boundary violation',
+        },
+      ],
     });
   });
 });
@@ -77,6 +127,14 @@ function makeAssessment(): GovernanceAssessment {
         maxScore: 100,
         unit: 'ratio',
       },
+      {
+        id: 'documentation-completeness',
+        name: 'Documentation Completeness',
+        value: 0.33,
+        score: 33,
+        maxScore: 100,
+        unit: 'ratio',
+      },
     ],
     signalBreakdown: {
       total: 6,
@@ -97,6 +155,43 @@ function makeAssessment(): GovernanceAssessment {
         { severity: 'error', count: 1 },
       ],
     },
+    metricBreakdown: {
+      families: [
+        {
+          family: 'architecture',
+          score: 80,
+          measurements: [
+            {
+              id: 'architectural-entropy',
+              name: 'Architectural Entropy',
+              score: 80,
+            },
+          ],
+        },
+        {
+          family: 'documentation',
+          score: 33,
+          measurements: [
+            {
+              id: 'documentation-completeness',
+              name: 'Documentation Completeness',
+              score: 33,
+            },
+          ],
+        },
+      ],
+    },
+    topIssues: [
+      {
+        type: 'domain-boundary-violation',
+        source: 'policy',
+        severity: 'error',
+        count: 2,
+        projects: ['orders-app', 'payments-feature'],
+        ruleId: 'domain-boundary',
+        message: 'Domain boundary violation',
+      },
+    ],
     health: {
       score: 80,
       grade: 'B',

--- a/packages/governance/src/reporting/top-issues.spec.ts
+++ b/packages/governance/src/reporting/top-issues.spec.ts
@@ -1,0 +1,108 @@
+import type { GovernanceSignal } from '../signal-engine/index.js';
+
+import { buildTopIssues } from './top-issues.js';
+
+describe('top issues helpers', () => {
+  it('groups identical issue scopes and ranks by severity then count', () => {
+    const issues = buildTopIssues([
+      signal({
+        id: 'warning-1',
+        type: 'cross-domain-dependency',
+        source: 'graph',
+        severity: 'warning',
+        sourceProjectId: 'shop-app',
+        targetProjectId: 'shared-ui',
+        relatedProjectIds: ['shared-ui', 'shop-app'],
+        message: 'Cross-domain dependency',
+      }),
+      signal({
+        id: 'warning-2',
+        type: 'cross-domain-dependency',
+        source: 'graph',
+        severity: 'warning',
+        sourceProjectId: 'shop-app',
+        targetProjectId: 'shared-ui',
+        relatedProjectIds: ['shared-ui', 'shop-app'],
+        message: 'Cross-domain dependency',
+      }),
+      signal({
+        id: 'error-1',
+        type: 'domain-boundary-violation',
+        source: 'policy',
+        severity: 'error',
+        sourceProjectId: 'orders-app',
+        targetProjectId: 'payments-feature',
+        relatedProjectIds: ['orders-app', 'payments-feature'],
+        message: 'Domain boundary violation',
+        metadata: { ruleId: 'domain-boundary' },
+      }),
+    ]);
+
+    expect(issues).toEqual([
+      {
+        type: 'domain-boundary-violation',
+        source: 'policy',
+        severity: 'error',
+        count: 1,
+        projects: ['orders-app', 'payments-feature'],
+        ruleId: 'domain-boundary',
+        message: 'Domain boundary violation',
+      },
+      {
+        type: 'cross-domain-dependency',
+        source: 'graph',
+        severity: 'warning',
+        count: 2,
+        projects: ['shared-ui', 'shop-app'],
+        ruleId: undefined,
+        message: 'Cross-domain dependency',
+      },
+    ]);
+  });
+
+  it('keeps deterministic ordering for same-severity issues', () => {
+    const issues = buildTopIssues([
+      signal({
+        id: 'ownership',
+        type: 'ownership-gap',
+        source: 'policy',
+        severity: 'warning',
+        sourceProjectId: 'billing-api',
+        relatedProjectIds: ['billing-api'],
+        message: 'Ownership gap',
+      }),
+      signal({
+        id: 'conformance',
+        type: 'conformance-violation',
+        source: 'conformance',
+        severity: 'warning',
+        sourceProjectId: 'billing-api',
+        relatedProjectIds: ['billing-api'],
+        message: 'Conformance issue',
+      }),
+    ]);
+
+    expect(issues.map((issue) => issue.type)).toEqual([
+      'conformance-violation',
+      'ownership-gap',
+    ]);
+  });
+});
+
+function signal(
+  overrides: Partial<GovernanceSignal> & Pick<GovernanceSignal, 'id'>
+): GovernanceSignal {
+  return {
+    id: overrides.id,
+    type: overrides.type ?? 'conformance-violation',
+    sourceProjectId: overrides.sourceProjectId,
+    targetProjectId: overrides.targetProjectId,
+    relatedProjectIds: overrides.relatedProjectIds ?? [],
+    severity: overrides.severity ?? 'warning',
+    category: overrides.category ?? 'boundary',
+    message: overrides.message ?? overrides.id,
+    metadata: overrides.metadata,
+    source: overrides.source ?? 'graph',
+    createdAt: overrides.createdAt ?? '2026-03-31T00:00:00.000Z',
+  };
+}

--- a/packages/governance/src/reporting/top-issues.ts
+++ b/packages/governance/src/reporting/top-issues.ts
@@ -1,0 +1,141 @@
+import type { GovernanceTopIssue } from '../core/index.js';
+import type {
+  GovernanceSignal,
+  GovernanceSignalSeverity,
+  GovernanceSignalSource,
+  GovernanceSignalType,
+} from '../signal-engine/index.js';
+
+const SOURCE_ORDER: Record<GovernanceSignalSource, number> = {
+  graph: 0,
+  conformance: 1,
+  policy: 2,
+};
+
+const TYPE_ORDER: Record<GovernanceSignalType, number> = {
+  'structural-dependency': 0,
+  'cross-domain-dependency': 1,
+  'missing-domain-context': 2,
+  'circular-dependency': 3,
+  'conformance-violation': 4,
+  'domain-boundary-violation': 5,
+  'layer-boundary-violation': 6,
+  'ownership-gap': 7,
+};
+
+const SEVERITY_ORDER: Record<GovernanceSignalSeverity, number> = {
+  error: 0,
+  warning: 1,
+  info: 2,
+};
+
+interface TopIssueGroup {
+  issue: GovernanceTopIssue;
+}
+
+export function buildTopIssues(
+  signals: GovernanceSignal[]
+): GovernanceTopIssue[] {
+  const groups = new Map<string, TopIssueGroup>();
+
+  for (const signal of signals) {
+    const key = buildGroupKey(signal);
+    const existing = groups.get(key);
+
+    if (existing) {
+      existing.issue.count += 1;
+      existing.issue.projects = mergeProjects(existing.issue.projects, signal);
+      if (!existing.issue.ruleId) {
+        existing.issue.ruleId = readRuleId(signal);
+      }
+      continue;
+    }
+
+    groups.set(key, {
+      issue: {
+        type: signal.type,
+        source: signal.source,
+        severity: signal.severity,
+        count: 1,
+        projects: projectsFromSignal(signal),
+        ruleId: readRuleId(signal),
+        message: signal.message,
+      },
+    });
+  }
+
+  return [...groups.values()]
+    .map((group) => group.issue)
+    .sort(compareTopIssues);
+}
+
+function buildGroupKey(signal: GovernanceSignal): string {
+  return [
+    signal.type,
+    signal.source,
+    signal.severity,
+    signal.sourceProjectId ?? '',
+    signal.targetProjectId ?? '',
+    signal.relatedProjectIds.join(','),
+  ].join('|');
+}
+
+function projectsFromSignal(signal: GovernanceSignal): string[] {
+  return [
+    ...new Set(
+      [
+        signal.sourceProjectId,
+        signal.targetProjectId,
+        ...signal.relatedProjectIds,
+      ].filter((value): value is string => !!value)
+    ),
+  ].sort((a, b) => a.localeCompare(b));
+}
+
+function mergeProjects(
+  existingProjects: string[],
+  signal: GovernanceSignal
+): string[] {
+  return [
+    ...new Set([...existingProjects, ...projectsFromSignal(signal)]),
+  ].sort((a, b) => a.localeCompare(b));
+}
+
+function readRuleId(signal: GovernanceSignal): string | undefined {
+  const ruleId = signal.metadata?.ruleId;
+  return typeof ruleId === 'string' && ruleId.length > 0 ? ruleId : undefined;
+}
+
+function compareTopIssues(
+  a: GovernanceTopIssue,
+  b: GovernanceTopIssue
+): number {
+  const severityOrder = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
+  if (severityOrder !== 0) {
+    return severityOrder;
+  }
+
+  const countOrder = b.count - a.count;
+  if (countOrder !== 0) {
+    return countOrder;
+  }
+
+  const typeOrder = TYPE_ORDER[a.type] - TYPE_ORDER[b.type];
+  if (typeOrder !== 0) {
+    return typeOrder;
+  }
+
+  const sourceOrder = SOURCE_ORDER[a.source] - SOURCE_ORDER[b.source];
+  if (sourceOrder !== 0) {
+    return sourceOrder;
+  }
+
+  const projectsOrder = a.projects
+    .join(',')
+    .localeCompare(b.projects.join(','));
+  if (projectsOrder !== 0) {
+    return projectsOrder;
+  }
+
+  return a.message.localeCompare(b.message);
+}

--- a/packages/governance/src/snapshot-store/index.spec.ts
+++ b/packages/governance/src/snapshot-store/index.spec.ts
@@ -63,6 +63,10 @@ describe('snapshot-store', () => {
           { severity: 'error', count: 0 },
         ],
       },
+      metricBreakdown: {
+        families: [],
+      },
+      topIssues: [],
       health: {
         score: 80,
         grade: 'B',


### PR DESCRIPTION
Extend nx-governance reporting with deterministic metric-family breakdowns and a unified top-issues section derived from governance signals instead of policy violations alone.

- add metricBreakdown families to governance assessments
- add unified topIssues ranked from filtered signals
- render Metric Families and Top Issues in CLI output
- keep JSON reporting additive and backward compatible
- add regression coverage and update README

Closes #48 Refs #36