### PR TITLE
feat(nx-governance): add core governance extension registration host

### DIFF
--- a/packages/governance/src/extensions/host.spec.ts
+++ b/packages/governance/src/extensions/host.spec.ts
@@ -1,0 +1,194 @@
+import {
+  GovernanceExtensionHostContext,
+  registerGovernanceExtensions,
+} from './host.js';
+
+describe('registerGovernanceExtensions', () => {
+  const baseContext: GovernanceExtensionHostContext = {
+    workspaceRoot: '/repo',
+    profileName: 'angular-cleanup',
+    options: {
+      output: 'cli',
+      reportType: 'health',
+    },
+    snapshot: {
+      root: '/repo',
+      projects: [],
+      dependencies: [],
+      codeownersByProject: {},
+    },
+    inventory: {
+      id: 'workspace',
+      name: 'workspace',
+      root: '/repo',
+      projects: [],
+      dependencies: [],
+    },
+  };
+
+  function createMissingModuleError(specifier: string): Error {
+    const error = new Error(`Cannot find module '${specifier}'`);
+    (error as Error & { code: string }).code = 'MODULE_NOT_FOUND';
+    return error;
+  }
+
+  it('discovers extensions from string and object plugin entries and registers them in nx.json order', async () => {
+    const registrationOrder: string[] = [];
+
+    const registry = await registerGovernanceExtensions(baseContext, {
+      nxJson: {
+        plugins: [
+          '@nx/jest/plugin',
+          { plugin: 'plugin-a' },
+          { plugin: 'plugin-b', options: { ignored: true } },
+        ],
+      },
+      moduleLoader: async (specifier) => {
+        if (specifier === '@nx/jest/plugin/governance-extension') {
+          throw createMissingModuleError(specifier);
+        }
+
+        if (specifier === 'plugin-a/governance-extension') {
+          return {
+            governanceExtension: {
+              id: 'plugin-a',
+              register(host: {
+                registerAnalyzer(value: unknown): void;
+                registerMetricProvider(value: unknown): void;
+              }) {
+                registrationOrder.push('plugin-a');
+                host.registerAnalyzer('analyzer-a');
+                host.registerMetricProvider('metric-a');
+              },
+            },
+          };
+        }
+
+        if (specifier === 'plugin-b/governance-extension') {
+          return {
+            governanceExtension: {
+              id: 'plugin-b',
+              register(host: {
+                registerSignalProvider(value: unknown): void;
+                registerRulePack(value: unknown): void;
+                registerEnricher(value: unknown): void;
+              }) {
+                registrationOrder.push('plugin-b');
+                host.registerSignalProvider('signal-b');
+                host.registerRulePack('rule-b');
+                host.registerEnricher('enricher-b');
+              },
+            },
+          };
+        }
+
+        throw new Error(`Unexpected specifier ${specifier}`);
+      },
+    });
+
+    expect(registrationOrder).toEqual(['plugin-a', 'plugin-b']);
+    expect(registry).toEqual({
+      analyzers: ['analyzer-a'],
+      metricProviders: ['metric-a'],
+      signalProviders: ['signal-b'],
+      rulePacks: ['rule-b'],
+      enrichers: ['enricher-b'],
+    });
+  });
+
+  it('passes immutable host context to registered extensions', async () => {
+    let receivedContext: GovernanceExtensionHostContext | undefined;
+
+    await registerGovernanceExtensions(baseContext, {
+      nxJson: {
+        plugins: ['plugin-a'],
+      },
+      moduleLoader: async () => ({
+        governanceExtension: {
+          id: 'plugin-a',
+          register(host: { context: GovernanceExtensionHostContext }) {
+            receivedContext = host.context;
+          },
+        },
+      }),
+    });
+
+    expect(receivedContext).toEqual(baseContext);
+    expect(Object.isFrozen(receivedContext)).toBe(true);
+    expect(Object.isFrozen(receivedContext?.options)).toBe(true);
+  });
+
+  it('ignores plugins without a governance extension entrypoint', async () => {
+    await expect(
+      registerGovernanceExtensions(baseContext, {
+        nxJson: {
+          plugins: ['plugin-a'],
+        },
+        moduleLoader: async (specifier) => {
+          throw createMissingModuleError(specifier);
+        },
+      })
+    ).resolves.toEqual({
+      analyzers: [],
+      metricProviders: [],
+      signalProviders: [],
+      rulePacks: [],
+      enrichers: [],
+    });
+  });
+
+  it('rejects invalid governance extension modules without a named export', async () => {
+    await expect(
+      registerGovernanceExtensions(baseContext, {
+        nxJson: {
+          plugins: ['plugin-a'],
+        },
+        moduleLoader: async () => ({
+          default: {
+            id: 'plugin-a',
+          },
+        }),
+      })
+    ).rejects.toThrow(
+      'Governance extension module must export a named "governanceExtension" definition.'
+    );
+  });
+
+  it('rejects duplicate extension ids', async () => {
+    await expect(
+      registerGovernanceExtensions(baseContext, {
+        nxJson: {
+          plugins: ['plugin-a', 'plugin-b'],
+        },
+        moduleLoader: async () => ({
+          governanceExtension: {
+            id: 'shared-extension',
+            register() {
+              return undefined;
+            },
+          },
+        }),
+      })
+    ).rejects.toThrow('Duplicate governance extension id "shared-extension"');
+  });
+
+  it('wraps registration failures with extension context', async () => {
+    await expect(
+      registerGovernanceExtensions(baseContext, {
+        nxJson: {
+          plugins: ['plugin-a'],
+        },
+        moduleLoader: async () => ({
+          governanceExtension: {
+            id: 'plugin-a',
+            register() {
+              throw new Error('boom');
+            },
+          },
+        }),
+      })
+    ).rejects.toThrow(
+      'Governance extension "plugin-a" from "plugin-a/governance-extension" failed during registration: boom'
+    );
+  });
+});

--- a/packages/governance/src/extensions/host.ts
+++ b/packages/governance/src/extensions/host.ts
@@ -1,0 +1,289 @@
+import { workspaceRoot as defaultWorkspaceRoot } from '@nx/devkit';
+import * as fs from 'node:fs';
+import path from 'node:path';
+
+import { GovernanceWorkspace } from '../core/models.js';
+import { AdapterWorkspaceSnapshot } from '../nx-adapter/types.js';
+
+export interface GovernanceExtensionDefinition {
+  id: string;
+  register(host: GovernanceExtensionHost): void | Promise<void>;
+}
+
+export interface GovernanceExtensionHostContext {
+  workspaceRoot: string;
+  profileName: string;
+  options: Readonly<Record<string, unknown>>;
+  snapshot: AdapterWorkspaceSnapshot;
+  inventory: GovernanceWorkspace;
+}
+
+export interface GovernanceExtensionRegistry {
+  analyzers: unknown[];
+  metricProviders: unknown[];
+  signalProviders: unknown[];
+  rulePacks: unknown[];
+  enrichers: unknown[];
+}
+
+interface NxJsonPluginConfig {
+  plugin?: string;
+}
+
+interface NxJsonShape {
+  plugins?: Array<string | NxJsonPluginConfig>;
+}
+
+interface DiscoveredGovernanceExtension {
+  pluginSpecifier: string;
+  moduleSpecifier: string;
+  definition: GovernanceExtensionDefinition;
+}
+
+export interface DiscoverGovernanceExtensionsOptions {
+  workspaceRoot?: string;
+  nxJson?: NxJsonShape;
+  moduleLoader?: GovernanceExtensionModuleLoader;
+}
+
+export type RegisterGovernanceExtensionsOptions =
+  DiscoverGovernanceExtensionsOptions;
+
+export type GovernanceExtensionModuleLoader = (
+  specifier: string
+) => Promise<unknown>;
+
+export class GovernanceExtensionHost {
+  readonly context: GovernanceExtensionHostContext;
+
+  private readonly registry: GovernanceExtensionRegistry = {
+    analyzers: [],
+    metricProviders: [],
+    signalProviders: [],
+    rulePacks: [],
+    enrichers: [],
+  };
+
+  constructor(context: GovernanceExtensionHostContext) {
+    this.context = Object.freeze({
+      ...context,
+      options: Object.freeze({ ...context.options }),
+    });
+  }
+
+  registerAnalyzer(analyzer: unknown): void {
+    this.registry.analyzers.push(analyzer);
+  }
+
+  registerMetricProvider(metricProvider: unknown): void {
+    this.registry.metricProviders.push(metricProvider);
+  }
+
+  registerSignalProvider(signalProvider: unknown): void {
+    this.registry.signalProviders.push(signalProvider);
+  }
+
+  registerRulePack(rulePack: unknown): void {
+    this.registry.rulePacks.push(rulePack);
+  }
+
+  registerEnricher(enricher: unknown): void {
+    this.registry.enrichers.push(enricher);
+  }
+
+  toRegistry(): GovernanceExtensionRegistry {
+    return {
+      analyzers: [...this.registry.analyzers],
+      metricProviders: [...this.registry.metricProviders],
+      signalProviders: [...this.registry.signalProviders],
+      rulePacks: [...this.registry.rulePacks],
+      enrichers: [...this.registry.enrichers],
+    };
+  }
+}
+
+export async function discoverGovernanceExtensions(
+  options: DiscoverGovernanceExtensionsOptions = {}
+): Promise<DiscoveredGovernanceExtension[]> {
+  const nxJson = options.nxJson ?? readNxJson(options.workspaceRoot);
+  const moduleLoader = options.moduleLoader ?? defaultGovernanceModuleLoader;
+  const extensions: DiscoveredGovernanceExtension[] = [];
+
+  for (const pluginSpecifier of normalizePluginSpecifiers(nxJson.plugins)) {
+    const moduleSpecifier =
+      toGovernanceExtensionModuleSpecifier(pluginSpecifier);
+
+    try {
+      const loadedModule = await moduleLoader(moduleSpecifier);
+      const governanceExtension =
+        readGovernanceExtensionDefinition(loadedModule);
+
+      extensions.push({
+        pluginSpecifier,
+        moduleSpecifier,
+        definition: governanceExtension,
+      });
+    } catch (error) {
+      if (isMissingGovernanceEntrypoint(error, moduleSpecifier)) {
+        continue;
+      }
+
+      throw error;
+    }
+  }
+
+  return extensions;
+}
+
+export async function registerGovernanceExtensions(
+  context: GovernanceExtensionHostContext,
+  options: RegisterGovernanceExtensionsOptions = {}
+): Promise<GovernanceExtensionRegistry> {
+  const host = new GovernanceExtensionHost(context);
+  const discoveredExtensions = await discoverGovernanceExtensions(options);
+  const seenExtensionIds = new Map<string, string>();
+
+  for (const extension of discoveredExtensions) {
+    validateGovernanceExtensionId(extension);
+
+    const previousModule = seenExtensionIds.get(extension.definition.id);
+    if (previousModule) {
+      throw new Error(
+        `Duplicate governance extension id "${extension.definition.id}" was found in "${previousModule}" and "${extension.moduleSpecifier}".`
+      );
+    }
+
+    seenExtensionIds.set(extension.definition.id, extension.moduleSpecifier);
+
+    try {
+      await extension.definition.register(host);
+    } catch (error) {
+      throw new Error(
+        `Governance extension "${extension.definition.id}" from "${
+          extension.moduleSpecifier
+        }" failed during registration: ${toErrorMessage(error)}`
+      );
+    }
+  }
+
+  return host.toRegistry();
+}
+
+function readNxJson(workspaceRoot = defaultWorkspaceRoot): NxJsonShape {
+  const nxJsonPath = path.join(workspaceRoot, 'nx.json');
+
+  try {
+    const raw = fs.readFileSync(nxJsonPath, 'utf8');
+    return JSON.parse(raw) as NxJsonShape;
+  } catch (error) {
+    throw new Error(
+      `Unable to read Nx plugin configuration from ${nxJsonPath}: ${toErrorMessage(
+        error
+      )}`
+    );
+  }
+}
+
+function normalizePluginSpecifiers(
+  plugins: NxJsonShape['plugins'] = []
+): string[] {
+  return plugins.flatMap((pluginEntry) => {
+    const pluginSpecifier =
+      typeof pluginEntry === 'string' ? pluginEntry : pluginEntry?.plugin;
+
+    if (
+      typeof pluginSpecifier !== 'string' ||
+      pluginSpecifier.trim().length === 0 ||
+      pluginSpecifier === '@anarchitects/nx-governance' ||
+      isLocalPluginSpecifier(pluginSpecifier)
+    ) {
+      return [];
+    }
+
+    return [pluginSpecifier];
+  });
+}
+
+function isLocalPluginSpecifier(pluginSpecifier: string): boolean {
+  return (
+    pluginSpecifier.startsWith('.') ||
+    pluginSpecifier.startsWith('/') ||
+    pluginSpecifier.startsWith('file:')
+  );
+}
+
+function toGovernanceExtensionModuleSpecifier(pluginSpecifier: string): string {
+  return `${pluginSpecifier}/governance-extension`;
+}
+
+function readGovernanceExtensionDefinition(
+  loadedModule: unknown
+): GovernanceExtensionDefinition {
+  const governanceExtension = (
+    loadedModule as { governanceExtension?: unknown }
+  )?.governanceExtension;
+
+  if (
+    !governanceExtension ||
+    typeof governanceExtension !== 'object' ||
+    typeof (governanceExtension as GovernanceExtensionDefinition).register !==
+      'function'
+  ) {
+    throw new Error(
+      'Governance extension module must export a named "governanceExtension" definition.'
+    );
+  }
+
+  return governanceExtension as GovernanceExtensionDefinition;
+}
+
+function validateGovernanceExtensionId(
+  extension: DiscoveredGovernanceExtension
+): void {
+  if (
+    typeof extension.definition.id !== 'string' ||
+    extension.definition.id.trim().length === 0
+  ) {
+    throw new Error(
+      `Governance extension module "${extension.moduleSpecifier}" must declare a non-empty "id".`
+    );
+  }
+}
+
+async function defaultGovernanceModuleLoader(
+  specifier: string
+): Promise<unknown> {
+  return import(specifier);
+}
+
+function isMissingGovernanceEntrypoint(
+  error: unknown,
+  moduleSpecifier: string
+): boolean {
+  const errorRecord =
+    error && typeof error === 'object'
+      ? (error as { code?: string; message?: string })
+      : undefined;
+
+  const message = errorRecord?.message;
+  if (typeof message !== 'string') {
+    return false;
+  }
+
+  const errorCode = errorRecord?.code;
+  const isModuleNotFoundCode =
+    errorCode === 'ERR_MODULE_NOT_FOUND' || errorCode === 'MODULE_NOT_FOUND';
+  const mentionsModuleSpecifier =
+    message.includes(`'${moduleSpecifier}'`) ||
+    message.includes(`"${moduleSpecifier}"`) ||
+    message.includes(` ${moduleSpecifier} `) ||
+    message.endsWith(moduleSpecifier);
+
+  return isModuleNotFoundCode
+    ? mentionsModuleSpecifier
+    : message.startsWith('Cannot find module') && mentionsModuleSpecifier;
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Unknown error.';
+}

--- a/packages/governance/src/plugin/run-governance.spec.ts
+++ b/packages/governance/src/plugin/run-governance.spec.ts
@@ -360,6 +360,34 @@ describe('runGovernance', () => {
     );
   });
 
+  it('keeps assessment output unchanged when nx plugins do not expose governance extensions', async () => {
+    jest.spyOn(logger, 'info').mockImplementation(() => undefined);
+
+    const nxJsonPath = path.join(workspaceRoot, 'nx.json');
+    const actualReadFileSync = fs.readFileSync;
+    const baseline = await runGovernance({ reportType: 'health' });
+
+    jest.spyOn(fs, 'readFileSync').mockImplementation(((filePath, encoding) => {
+      if (path.resolve(String(filePath)) === nxJsonPath) {
+        return JSON.stringify({
+          plugins: [
+            '@nx/jest/plugin',
+            { plugin: '@nx/vite/plugin' },
+            '@anarchitects/nx-governance',
+          ],
+        });
+      }
+
+      return actualReadFileSync(filePath, encoding as never);
+    }) as typeof fs.readFileSync);
+
+    const withGovernanceDiscovery = await runGovernance({
+      reportType: 'health',
+    });
+
+    expect(withGovernanceDiscovery.assessment).toEqual(baseline.assessment);
+  });
+
   it('filters type and severity breakdowns to the active report type', async () => {
     jest.spyOn(logger, 'info').mockImplementation(() => undefined);
 

--- a/packages/governance/src/plugin/run-governance.ts
+++ b/packages/governance/src/plugin/run-governance.ts
@@ -73,6 +73,7 @@ import {
   mergeGovernanceSignals,
 } from '../signal-engine/index.js';
 import { WorkspaceGraphSnapshot } from '../nx-adapter/graph-adapter.js';
+import { registerGovernanceExtensions } from '../extensions/host.js';
 
 export interface GovernanceRunOptions {
   profile?: string;
@@ -1470,6 +1471,13 @@ async function buildAssessment(
 
   const snapshot = await readNxWorkspaceSnapshot();
   const inventory = buildInventory(snapshot, overrides);
+  await registerGovernanceExtensions({
+    workspaceRoot,
+    profileName,
+    options: { ...options },
+    snapshot,
+    inventory,
+  });
   const allViolations = evaluatePolicies(inventory, effectiveProfile);
   const graphSignals = buildGraphSignals(toWorkspaceGraphSnapshot(inventory));
   const policySignals = buildPolicySignals(allViolations);


### PR DESCRIPTION
Introduce the internal extension host for nx-governance and wire a registration phase into the governance assessment pipeline.

This adds deterministic discovery from nx.json plugins, conventional `<plugin>/governance-extension` loading, ordered registration, duplicate id validation, and regression coverage while keeping assessment output unchanged for now.

Closes #61 Refs #41