### PR TITLE
feat(nx-governance): add typed extension contracts and pipeline integration

### DIFF
--- a/packages/governance/src/core/models.ts
+++ b/packages/governance/src/core/models.ts
@@ -1,4 +1,5 @@
 import type {
+  GovernanceSignalCategory,
   GovernanceSignalSeverity,
   GovernanceSignalSource,
   GovernanceSignalType,
@@ -42,18 +43,32 @@ export interface Violation {
   ruleId: string;
   project: string;
   severity: 'error' | 'warning' | 'info';
+  category: GovernanceSignalCategory | 'architecture' | 'documentation';
   message: string;
   details?: Record<string, unknown>;
   recommendation?: string;
+  sourcePluginId?: string;
 }
+
+export type KnownGovernanceMetricFamily =
+  | 'architecture'
+  | 'boundaries'
+  | 'ownership'
+  | 'documentation';
+
+export type GovernanceMetricFamily =
+  | KnownGovernanceMetricFamily
+  | (string & {});
 
 export interface Measurement {
   id: string;
   name: string;
+  family: GovernanceMetricFamily;
   value: number;
   score: number;
   maxScore: number;
   unit: 'ratio' | 'count' | 'score';
+  sourcePluginId?: string;
 }
 
 export interface Recommendation {
@@ -100,7 +115,7 @@ export interface HealthScore {
 }
 
 export interface SignalBreakdownEntry {
-  source: 'graph' | 'conformance' | 'policy';
+  source: GovernanceSignalSource;
   count: number;
 }
 
@@ -120,12 +135,6 @@ export interface SignalBreakdown {
   byType: SignalTypeBreakdownEntry[];
   bySeverity: SignalSeverityBreakdownEntry[];
 }
-
-export type GovernanceMetricFamily =
-  | 'architecture'
-  | 'boundaries'
-  | 'ownership'
-  | 'documentation';
 
 export interface MetricBreakdownMeasurement {
   id: Measurement['id'];
@@ -151,6 +160,7 @@ export interface GovernanceTopIssue {
   projects: string[];
   ruleId?: string;
   message: string;
+  sourcePluginId?: string;
 }
 
 export interface GovernanceAssessment {

--- a/packages/governance/src/core/profile.ts
+++ b/packages/governance/src/core/profile.ts
@@ -1,4 +1,4 @@
-import { HealthStatusThresholds } from './models.js';
+import { HealthStatusThresholds, Measurement } from './models.js';
 
 export const DEFAULT_HEALTH_STATUS_THRESHOLDS: HealthStatusThresholds = {
   goodMinScore: 85,
@@ -18,14 +18,7 @@ export interface GovernanceProfile {
   health: {
     statusThresholds: HealthStatusThresholds;
   };
-  metrics: {
-    architecturalEntropyWeight: number;
-    dependencyComplexityWeight: number;
-    domainIntegrityWeight: number;
-    ownershipCoverageWeight: number;
-    documentationCompletenessWeight: number;
-    layerIntegrityWeight: number;
-  };
+  metrics: Record<Measurement['id'], number>;
 }
 
 export interface ProfileOverrides {
@@ -36,7 +29,7 @@ export interface ProfileOverrides {
   health?: {
     statusThresholds?: Partial<HealthStatusThresholds>;
   };
-  metrics?: Partial<GovernanceProfile['metrics']>;
+  metrics?: Partial<Record<string, number>>;
   projectOverrides: Record<
     string,
     {

--- a/packages/governance/src/extensions/contracts.ts
+++ b/packages/governance/src/extensions/contracts.ts
@@ -1,0 +1,75 @@
+import {
+  GovernanceProfile,
+  GovernanceWorkspace,
+  Measurement,
+  Violation,
+} from '../core/index.js';
+import { AdapterWorkspaceSnapshot } from '../nx-adapter/types.js';
+import { GovernanceSignal } from '../signal-engine/index.js';
+
+export interface GovernanceExtensionHostContext {
+  workspaceRoot: string;
+  profileName: string;
+  options: Readonly<Record<string, unknown>>;
+  snapshot: AdapterWorkspaceSnapshot;
+  inventory: GovernanceWorkspace;
+}
+
+export interface GovernanceExtensionDefinition {
+  id: string;
+  register(host: GovernanceExtensionHost): void | Promise<void>;
+}
+
+export interface GovernanceExtensionHost {
+  readonly context: GovernanceExtensionHostContext;
+  registerEnricher(enricher: GovernanceWorkspaceEnricher): void;
+  registerRulePack(rulePack: GovernanceRulePack): void;
+  registerSignalProvider(signalProvider: GovernanceSignalProvider): void;
+  registerMetricProvider(metricProvider: GovernanceMetricProvider): void;
+}
+
+export interface GovernanceExtensionExecutionInput {
+  workspace: GovernanceWorkspace;
+  profile: GovernanceProfile;
+  context: GovernanceExtensionHostContext;
+}
+
+export type GovernanceWorkspaceEnricherInput =
+  GovernanceExtensionExecutionInput;
+
+export type GovernanceRulePackInput = GovernanceExtensionExecutionInput;
+
+export interface GovernanceSignalProviderInput
+  extends GovernanceExtensionExecutionInput {
+  violations: Violation[];
+  signals: GovernanceSignal[];
+}
+
+export interface GovernanceMetricProviderInput
+  extends GovernanceExtensionExecutionInput {
+  signals: GovernanceSignal[];
+  measurements: Measurement[];
+  violations: Violation[];
+}
+
+export interface GovernanceWorkspaceEnricher {
+  enrichWorkspace(
+    input: GovernanceWorkspaceEnricherInput
+  ): GovernanceWorkspace | Promise<GovernanceWorkspace>;
+}
+
+export interface GovernanceRulePack {
+  evaluate(input: GovernanceRulePackInput): Violation[] | Promise<Violation[]>;
+}
+
+export interface GovernanceSignalProvider {
+  provideSignals(
+    input: GovernanceSignalProviderInput
+  ): GovernanceSignal[] | Promise<GovernanceSignal[]>;
+}
+
+export interface GovernanceMetricProvider {
+  provideMetrics(
+    input: GovernanceMetricProviderInput
+  ): Measurement[] | Promise<Measurement[]>;
+}

--- a/packages/governance/src/extensions/host.spec.ts
+++ b/packages/governance/src/extensions/host.spec.ts
@@ -53,12 +53,12 @@ describe('registerGovernanceExtensions', () => {
             governanceExtension: {
               id: 'plugin-a',
               register(host: {
-                registerAnalyzer(value: unknown): void;
                 registerMetricProvider(value: unknown): void;
+                registerRulePack(value: unknown): void;
               }) {
                 registrationOrder.push('plugin-a');
-                host.registerAnalyzer('analyzer-a');
                 host.registerMetricProvider('metric-a');
+                host.registerRulePack('rule-a');
               },
             },
           };
@@ -88,11 +88,13 @@ describe('registerGovernanceExtensions', () => {
 
     expect(registrationOrder).toEqual(['plugin-a', 'plugin-b']);
     expect(registry).toEqual({
-      analyzers: ['analyzer-a'],
-      metricProviders: ['metric-a'],
-      signalProviders: ['signal-b'],
-      rulePacks: ['rule-b'],
-      enrichers: ['enricher-b'],
+      metricProviders: [{ pluginId: 'plugin-a', contribution: 'metric-a' }],
+      signalProviders: [{ pluginId: 'plugin-b', contribution: 'signal-b' }],
+      rulePacks: [
+        { pluginId: 'plugin-a', contribution: 'rule-a' },
+        { pluginId: 'plugin-b', contribution: 'rule-b' },
+      ],
+      enrichers: [{ pluginId: 'plugin-b', contribution: 'enricher-b' }],
     });
   });
 
@@ -129,7 +131,6 @@ describe('registerGovernanceExtensions', () => {
         },
       })
     ).resolves.toEqual({
-      analyzers: [],
       metricProviders: [],
       signalProviders: [],
       rulePacks: [],

--- a/packages/governance/src/extensions/host.ts
+++ b/packages/governance/src/extensions/host.ts
@@ -2,28 +2,32 @@ import { workspaceRoot as defaultWorkspaceRoot } from '@nx/devkit';
 import * as fs from 'node:fs';
 import path from 'node:path';
 
-import { GovernanceWorkspace } from '../core/models.js';
-import { AdapterWorkspaceSnapshot } from '../nx-adapter/types.js';
+import { GovernanceWorkspace, Measurement, Violation } from '../core/index.js';
+import { GovernanceSignal } from '../signal-engine/index.js';
+import {
+  GovernanceExtensionDefinition,
+  GovernanceExtensionHost as GovernanceExtensionHostContract,
+  GovernanceExtensionHostContext,
+  GovernanceMetricProvider,
+  GovernanceMetricProviderInput,
+  GovernanceRulePack,
+  GovernanceRulePackInput,
+  GovernanceSignalProvider,
+  GovernanceSignalProviderInput,
+  GovernanceWorkspaceEnricher,
+  GovernanceWorkspaceEnricherInput,
+} from './contracts.js';
 
-export interface GovernanceExtensionDefinition {
-  id: string;
-  register(host: GovernanceExtensionHost): void | Promise<void>;
-}
-
-export interface GovernanceExtensionHostContext {
-  workspaceRoot: string;
-  profileName: string;
-  options: Readonly<Record<string, unknown>>;
-  snapshot: AdapterWorkspaceSnapshot;
-  inventory: GovernanceWorkspace;
+interface RegisteredGovernanceContribution<T> {
+  pluginId: string;
+  contribution: T;
 }
 
 export interface GovernanceExtensionRegistry {
-  analyzers: unknown[];
-  metricProviders: unknown[];
-  signalProviders: unknown[];
-  rulePacks: unknown[];
-  enrichers: unknown[];
+  metricProviders: RegisteredGovernanceContribution<GovernanceMetricProvider>[];
+  signalProviders: RegisteredGovernanceContribution<GovernanceSignalProvider>[];
+  rulePacks: RegisteredGovernanceContribution<GovernanceRulePack>[];
+  enrichers: RegisteredGovernanceContribution<GovernanceWorkspaceEnricher>[];
 }
 
 interface NxJsonPluginConfig {
@@ -53,47 +57,58 @@ export type GovernanceExtensionModuleLoader = (
   specifier: string
 ) => Promise<unknown>;
 
-export class GovernanceExtensionHost {
+export class GovernanceExtensionHost
+  implements GovernanceExtensionHostContract
+{
   readonly context: GovernanceExtensionHostContext;
 
   private readonly registry: GovernanceExtensionRegistry = {
-    analyzers: [],
     metricProviders: [],
     signalProviders: [],
     rulePacks: [],
     enrichers: [],
   };
 
-  constructor(context: GovernanceExtensionHostContext) {
+  private readonly pluginId: string;
+
+  constructor(context: GovernanceExtensionHostContext, pluginId: string) {
     this.context = Object.freeze({
       ...context,
       options: Object.freeze({ ...context.options }),
     });
+    this.pluginId = pluginId;
   }
 
-  registerAnalyzer(analyzer: unknown): void {
-    this.registry.analyzers.push(analyzer);
+  registerMetricProvider(metricProvider: GovernanceMetricProvider): void {
+    this.registry.metricProviders.push({
+      pluginId: this.pluginId,
+      contribution: metricProvider,
+    });
   }
 
-  registerMetricProvider(metricProvider: unknown): void {
-    this.registry.metricProviders.push(metricProvider);
+  registerSignalProvider(signalProvider: GovernanceSignalProvider): void {
+    this.registry.signalProviders.push({
+      pluginId: this.pluginId,
+      contribution: signalProvider,
+    });
   }
 
-  registerSignalProvider(signalProvider: unknown): void {
-    this.registry.signalProviders.push(signalProvider);
+  registerRulePack(rulePack: GovernanceRulePack): void {
+    this.registry.rulePacks.push({
+      pluginId: this.pluginId,
+      contribution: rulePack,
+    });
   }
 
-  registerRulePack(rulePack: unknown): void {
-    this.registry.rulePacks.push(rulePack);
-  }
-
-  registerEnricher(enricher: unknown): void {
-    this.registry.enrichers.push(enricher);
+  registerEnricher(enricher: GovernanceWorkspaceEnricher): void {
+    this.registry.enrichers.push({
+      pluginId: this.pluginId,
+      contribution: enricher,
+    });
   }
 
   toRegistry(): GovernanceExtensionRegistry {
     return {
-      analyzers: [...this.registry.analyzers],
       metricProviders: [...this.registry.metricProviders],
       signalProviders: [...this.registry.signalProviders],
       rulePacks: [...this.registry.rulePacks],
@@ -139,7 +154,12 @@ export async function registerGovernanceExtensions(
   context: GovernanceExtensionHostContext,
   options: RegisterGovernanceExtensionsOptions = {}
 ): Promise<GovernanceExtensionRegistry> {
-  const host = new GovernanceExtensionHost(context);
+  const registry: GovernanceExtensionRegistry = {
+    metricProviders: [],
+    signalProviders: [],
+    rulePacks: [],
+    enrichers: [],
+  };
   const discoveredExtensions = await discoverGovernanceExtensions(options);
   const seenExtensionIds = new Map<string, string>();
 
@@ -156,7 +176,12 @@ export async function registerGovernanceExtensions(
     seenExtensionIds.set(extension.definition.id, extension.moduleSpecifier);
 
     try {
+      const host = new GovernanceExtensionHost(
+        context,
+        extension.definition.id
+      );
       await extension.definition.register(host);
+      mergeRegistry(registry, host.toRegistry());
     } catch (error) {
       throw new Error(
         `Governance extension "${extension.definition.id}" from "${
@@ -166,7 +191,79 @@ export async function registerGovernanceExtensions(
     }
   }
 
-  return host.toRegistry();
+  return registry;
+}
+
+export async function applyGovernanceEnrichers(
+  registry: GovernanceExtensionRegistry,
+  input: GovernanceWorkspaceEnricherInput
+): Promise<GovernanceWorkspace> {
+  let workspace = input.workspace;
+
+  for (const enricher of registry.enrichers) {
+    const enrichedWorkspace = await enricher.contribution.enrichWorkspace({
+      ...input,
+      workspace,
+    });
+    workspace = enrichedWorkspace;
+  }
+
+  return workspace;
+}
+
+export async function evaluateGovernanceRulePacks(
+  registry: GovernanceExtensionRegistry,
+  input: GovernanceRulePackInput
+): Promise<Violation[]> {
+  const violations = await Promise.all(
+    registry.rulePacks.map(async (rulePack) => {
+      const providedViolations = await rulePack.contribution.evaluate(input);
+      return providedViolations.map((violation) => ({
+        ...violation,
+        sourcePluginId: violation.sourcePluginId ?? rulePack.pluginId,
+      }));
+    })
+  );
+
+  return violations.flat();
+}
+
+export async function collectGovernanceSignals(
+  registry: GovernanceExtensionRegistry,
+  input: GovernanceSignalProviderInput
+): Promise<GovernanceSignal[]> {
+  const signals = await Promise.all(
+    registry.signalProviders.map(async (signalProvider) => {
+      const providedSignals = await signalProvider.contribution.provideSignals(
+        input
+      );
+      return providedSignals.map((signal) => ({
+        ...signal,
+        source: 'extension' as const,
+        sourcePluginId: signal.sourcePluginId ?? signalProvider.pluginId,
+      }));
+    })
+  );
+
+  return signals.flat();
+}
+
+export async function collectGovernanceMeasurements(
+  registry: GovernanceExtensionRegistry,
+  input: GovernanceMetricProviderInput
+): Promise<Measurement[]> {
+  const measurements = await Promise.all(
+    registry.metricProviders.map(async (metricProvider) => {
+      const providedMeasurements =
+        await metricProvider.contribution.provideMetrics(input);
+      return providedMeasurements.map((measurement) => ({
+        ...measurement,
+        sourcePluginId: measurement.sourcePluginId ?? metricProvider.pluginId,
+      }));
+    })
+  );
+
+  return measurements.flat();
 }
 
 function readNxJson(workspaceRoot = defaultWorkspaceRoot): NxJsonShape {
@@ -182,6 +279,16 @@ function readNxJson(workspaceRoot = defaultWorkspaceRoot): NxJsonShape {
       )}`
     );
   }
+}
+
+function mergeRegistry(
+  target: GovernanceExtensionRegistry,
+  source: GovernanceExtensionRegistry
+): void {
+  target.metricProviders.push(...source.metricProviders);
+  target.signalProviders.push(...source.signalProviders);
+  target.rulePacks.push(...source.rulePacks);
+  target.enrichers.push(...source.enrichers);
 }
 
 function normalizePluginSpecifiers(

--- a/packages/governance/src/index.ts
+++ b/packages/governance/src/index.ts
@@ -30,3 +30,4 @@ export * from './nx-adapter/graph-adapter.js';
 export * from './conformance-adapter/conformance-adapter.js';
 export * from './signal-engine/index.js';
 export * from './metric-engine/calculate-metrics.js';
+export * from './extensions/contracts.js';

--- a/packages/governance/src/metric-engine/aggregate-signals.ts
+++ b/packages/governance/src/metric-engine/aggregate-signals.ts
@@ -22,6 +22,7 @@ const SOURCE_SORT_ORDER: Record<GovernanceSignalSource, number> = {
   graph: 0,
   conformance: 1,
   policy: 2,
+  extension: 3,
 };
 
 const SEVERITY_SORT_ORDER: Record<GovernanceSignalSeverity, number> = {
@@ -47,7 +48,9 @@ const SIGNAL_TYPE_WEIGHTS: Record<GovernanceSignalType, number> = {
   'ownership-gap': 0.5,
 };
 
-export function aggregateSignals(signals: GovernanceSignal[]): SignalAggregate[] {
+export function aggregateSignals(
+  signals: GovernanceSignal[]
+): SignalAggregate[] {
   const groupedSignals = new Map<string, SignalAggregate>();
 
   for (const signal of signals) {
@@ -119,7 +122,10 @@ function signalWeight(signal: GovernanceSignal): number {
   );
 }
 
-function compareSignalAggregates(a: SignalAggregate, b: SignalAggregate): number {
+function compareSignalAggregates(
+  a: SignalAggregate,
+  b: SignalAggregate
+): number {
   const sourceOrder = SOURCE_SORT_ORDER[a.source] - SOURCE_SORT_ORDER[b.source];
   if (sourceOrder !== 0) {
     return sourceOrder;
@@ -150,7 +156,9 @@ function compareSignalAggregates(a: SignalAggregate, b: SignalAggregate): number
     return targetProjectOrder;
   }
 
-  return a.relatedProjectIds.join(',').localeCompare(b.relatedProjectIds.join(','));
+  return a.relatedProjectIds
+    .join(',')
+    .localeCompare(b.relatedProjectIds.join(','));
 }
 
 function roundWeight(value: number): number {

--- a/packages/governance/src/metric-engine/calculate-metrics.ts
+++ b/packages/governance/src/metric-engine/calculate-metrics.ts
@@ -50,33 +50,39 @@ export function calculateMetrics(input: MetricEngineInput): Measurement[] {
     makeScore(
       'architectural-entropy',
       'Architectural Entropy',
+      'architecture',
       entropyPenaltyWeight / Math.max(canonicalDependencyCount, 1)
     ),
     makeScore(
       'dependency-complexity',
       'Dependency Complexity',
+      'architecture',
       canonicalDependencyCount / projectCount / 4
     ),
     makeScore(
       'domain-integrity',
       'Domain Integrity',
+      'boundaries',
       domainViolationWeight / Math.max(canonicalDependencyCount, 1)
     ),
     makeScore(
       'ownership-coverage',
       'Ownership Coverage',
+      'ownership',
       ownedProjects / projectCount,
       true
     ),
     makeScore(
       'documentation-completeness',
       'Documentation Completeness',
+      'documentation',
       documentedProjects / projectCount,
       true
     ),
     makeScore(
       'layer-integrity',
       'Layer Integrity',
+      'boundaries',
       layerViolationWeight / Math.max(canonicalDependencyCount, 1)
     ),
   ];
@@ -85,6 +91,7 @@ export function calculateMetrics(input: MetricEngineInput): Measurement[] {
 function makeScore(
   id: string,
   name: string,
+  family: Measurement['family'],
   ratio: number,
   ratioIsPositive = false
 ): Measurement {
@@ -97,6 +104,7 @@ function makeScore(
   return {
     id,
     name,
+    family,
     value,
     score,
     maxScore: 100,

--- a/packages/governance/src/plugin/run-governance.spec.ts
+++ b/packages/governance/src/plugin/run-governance.spec.ts
@@ -10,6 +10,13 @@ import {
   angularCleanupProfile,
   loadProfileOverrides,
 } from '../presets/angular-cleanup/profile.js';
+import type {
+  GovernanceExtensionHost,
+  GovernanceMetricProviderInput,
+  GovernanceRulePackInput,
+  GovernanceSignalProviderInput,
+  GovernanceWorkspaceEnricherInput,
+} from '../extensions/contracts.js';
 import {
   runGovernance,
   runGovernanceAiDrift,
@@ -39,23 +46,23 @@ describe('runGovernance', () => {
     const overrides = await loadProfileOverrides(workspaceRoot, profileName);
     const resolvedWeights = {
       'architectural-entropy':
-        overrides.metrics?.architecturalEntropyWeight ??
-        angularCleanupProfile.metrics.architecturalEntropyWeight,
+        overrides.metrics?.['architectural-entropy'] ??
+        angularCleanupProfile.metrics['architectural-entropy'],
       'dependency-complexity':
-        overrides.metrics?.dependencyComplexityWeight ??
-        angularCleanupProfile.metrics.dependencyComplexityWeight,
+        overrides.metrics?.['dependency-complexity'] ??
+        angularCleanupProfile.metrics['dependency-complexity'],
       'domain-integrity':
-        overrides.metrics?.domainIntegrityWeight ??
-        angularCleanupProfile.metrics.domainIntegrityWeight,
+        overrides.metrics?.['domain-integrity'] ??
+        angularCleanupProfile.metrics['domain-integrity'],
       'ownership-coverage':
-        overrides.metrics?.ownershipCoverageWeight ??
-        angularCleanupProfile.metrics.ownershipCoverageWeight,
+        overrides.metrics?.['ownership-coverage'] ??
+        angularCleanupProfile.metrics['ownership-coverage'],
       'documentation-completeness':
-        overrides.metrics?.documentationCompletenessWeight ??
-        angularCleanupProfile.metrics.documentationCompletenessWeight,
+        overrides.metrics?.['documentation-completeness'] ??
+        angularCleanupProfile.metrics['documentation-completeness'],
       'layer-integrity':
-        overrides.metrics?.layerIntegrityWeight ??
-        angularCleanupProfile.metrics.layerIntegrityWeight,
+        overrides.metrics?.['layer-integrity'] ??
+        angularCleanupProfile.metrics['layer-integrity'],
     };
     const resolvedStatusThresholds =
       overrides.health?.statusThresholds ??
@@ -76,7 +83,7 @@ describe('runGovernance', () => {
     ]);
     expect(
       boundaries.assessment.measurements.map((metric) => metric.id)
-    ).toEqual(['architectural-entropy', 'domain-integrity', 'layer-integrity']);
+    ).toEqual(['domain-integrity', 'layer-integrity']);
     expect(
       ownership.assessment.measurements.map((metric) => metric.id)
     ).toEqual(['ownership-coverage']);
@@ -86,6 +93,7 @@ describe('runGovernance', () => {
       'architectural-entropy',
       'dependency-complexity',
       'domain-integrity',
+      'layer-integrity',
     ]);
 
     expect(health.assessment.health).toEqual(
@@ -118,6 +126,7 @@ describe('runGovernance', () => {
         source: 'policy',
         count: health.assessment.signalBreakdown.bySource[2].count,
       },
+      { source: 'extension', count: 0 },
     ]);
     expect(health.assessment.signalBreakdown.bySeverity).toEqual([
       {
@@ -146,7 +155,7 @@ describe('runGovernance', () => {
       boundaries.assessment.metricBreakdown.families.map(
         (entry) => entry.family
       )
-    ).toEqual(['architecture', 'boundaries']);
+    ).toEqual(['boundaries']);
     expect(
       ownership.assessment.metricBreakdown.families.map((entry) => entry.family)
     ).toEqual(['ownership']);
@@ -388,6 +397,151 @@ describe('runGovernance', () => {
     expect(withGovernanceDiscovery.assessment).toEqual(baseline.assessment);
   });
 
+  it('consumes typed extension enrichers, rule packs, signals, and metrics in a governance run', async () => {
+    jest.spyOn(logger, 'info').mockImplementation(() => undefined);
+    const nxJsonPath = path.join(workspaceRoot, 'nx.json');
+    const actualReadFileSync = fs.readFileSync;
+
+    jest.doMock(
+      'test-plugin/governance-extension',
+      () => ({
+        governanceExtension: {
+          id: 'test-plugin',
+          register(host: GovernanceExtensionHost) {
+            host.registerEnricher({
+              enrichWorkspace({ workspace }: GovernanceWorkspaceEnricherInput) {
+                return {
+                  ...workspace,
+                  projects: workspace.projects.map((project, index) =>
+                    index === 0
+                      ? {
+                          ...project,
+                          metadata: {
+                            ...project.metadata,
+                            extensionTouched: true,
+                          },
+                        }
+                      : project
+                  ),
+                };
+              },
+            });
+            host.registerRulePack({
+              evaluate({ workspace }: GovernanceRulePackInput) {
+                return [
+                  {
+                    id: 'extension-violation',
+                    ruleId: 'extension-boundary',
+                    project: workspace.projects[0]?.name ?? 'unknown',
+                    severity: 'warning',
+                    category: 'boundary',
+                    message: 'Extension rule violation',
+                  },
+                ];
+              },
+            });
+            host.registerSignalProvider({
+              provideSignals({
+                workspace,
+                violations,
+                signals,
+              }: GovernanceSignalProviderInput) {
+                return [
+                  {
+                    id: 'extension-signal',
+                    type: 'extension-warning',
+                    sourceProjectId: workspace.projects[0]?.name,
+                    relatedProjectIds: workspace.projects[0]
+                      ? [workspace.projects[0].name]
+                      : [],
+                    severity: 'warning',
+                    category: 'boundary',
+                    message: `Extension signal for ${violations.length} violations and ${signals.length} core signals.`,
+                    source: 'extension',
+                    createdAt: new Date().toISOString(),
+                  },
+                ];
+              },
+            });
+            host.registerMetricProvider({
+              provideMetrics({
+                workspace,
+                measurements,
+              }: GovernanceMetricProviderInput) {
+                return [
+                  {
+                    id: 'extension-coverage',
+                    name: 'Extension Coverage',
+                    family: 'architecture',
+                    value: workspace.projects.length > 0 ? 1 : 0,
+                    score: 80,
+                    maxScore: 100,
+                    unit: 'ratio',
+                  },
+                ].filter(() => measurements.length > 0);
+              },
+            });
+          },
+        },
+      }),
+      { virtual: true }
+    );
+
+    jest.spyOn(fs, 'readFileSync').mockImplementation(((filePath, encoding) => {
+      if (path.resolve(String(filePath)) === nxJsonPath) {
+        return JSON.stringify({
+          plugins: ['test-plugin'],
+        });
+      }
+
+      return actualReadFileSync(filePath, encoding as never);
+    }) as typeof fs.readFileSync);
+
+    const result = await runGovernance({ reportType: 'health' });
+
+    expect(
+      result.assessment.workspace.projects[0]?.metadata.extensionTouched
+    ).toBe(true);
+    expect(
+      result.assessment.violations.find(
+        (violation) => violation.ruleId === 'extension-boundary'
+      )
+    ).toEqual(
+      expect.objectContaining({
+        category: 'boundary',
+        sourcePluginId: 'test-plugin',
+      })
+    );
+    expect(result.assessment.signalBreakdown.bySource).toContainEqual({
+      source: 'extension',
+      count: 1,
+    });
+    expect(result.assessment.signalBreakdown.byType).toContainEqual({
+      type: 'extension-warning',
+      count: 1,
+    });
+    expect(
+      result.assessment.measurements.find(
+        (measurement) => measurement.id === 'extension-coverage'
+      )
+    ).toEqual(
+      expect.objectContaining({
+        family: 'architecture',
+        sourcePluginId: 'test-plugin',
+      })
+    );
+    expect(result.assessment.metricBreakdown.families).toContainEqual(
+      expect.objectContaining({
+        family: 'architecture',
+        measurements: expect.arrayContaining([
+          expect.objectContaining({ id: 'extension-coverage' }),
+        ]),
+      })
+    );
+
+    jest.dontMock('test-plugin/governance-extension');
+  });
+
   it('filters type and severity breakdowns to the active report type', async () => {
     jest.spyOn(logger, 'info').mockImplementation(() => undefined);
 
@@ -440,6 +594,7 @@ describe('runGovernance', () => {
         { source: 'graph', count: 0 },
         { source: 'conformance', count: 1 },
         { source: 'policy', count: 0 },
+        { source: 'extension', count: 0 },
       ]);
       expect(ownership.assessment.signalBreakdown.byType).toEqual([
         { type: 'conformance-violation', count: 1 },

--- a/packages/governance/src/plugin/run-governance.ts
+++ b/packages/governance/src/plugin/run-governance.ts
@@ -4,7 +4,6 @@ import { GovernanceAssessment, GovernanceProfile } from '../core/index.js';
 import {
   buildRecommendations,
   calculateHealthScore,
-  MetricWeights,
 } from '../health-engine/calculate-health.js';
 import { buildInventory } from '../inventory/build-inventory.js';
 import { calculateMetrics } from '../metric-engine/calculate-metrics.js';
@@ -73,7 +72,13 @@ import {
   mergeGovernanceSignals,
 } from '../signal-engine/index.js';
 import { WorkspaceGraphSnapshot } from '../nx-adapter/graph-adapter.js';
-import { registerGovernanceExtensions } from '../extensions/host.js';
+import {
+  applyGovernanceEnrichers,
+  collectGovernanceMeasurements,
+  collectGovernanceSignals,
+  evaluateGovernanceRulePacks,
+  registerGovernanceExtensions,
+} from '../extensions/host.js';
 
 export interface GovernanceRunOptions {
   profile?: string;
@@ -1465,42 +1470,102 @@ async function buildAssessment(
     },
     metrics: {
       ...angularCleanupProfile.metrics,
-      ...(overrides.metrics ?? {}),
+      ...normalizeMetricWeights(overrides.metrics),
     },
   };
 
   const snapshot = await readNxWorkspaceSnapshot();
   const inventory = buildInventory(snapshot, overrides);
-  await registerGovernanceExtensions({
+  const extensionRegistry = await registerGovernanceExtensions({
     workspaceRoot,
     profileName,
     options: { ...options },
     snapshot,
     inventory,
   });
-  const allViolations = evaluatePolicies(inventory, effectiveProfile);
-  const graphSignals = buildGraphSignals(toWorkspaceGraphSnapshot(inventory));
+  const enrichedInventory = await applyGovernanceEnrichers(extensionRegistry, {
+    workspace: inventory,
+    profile: effectiveProfile,
+    context: {
+      workspaceRoot,
+      profileName,
+      options: { ...options },
+      snapshot,
+      inventory,
+    },
+  });
+  const coreViolations = evaluatePolicies(enrichedInventory, effectiveProfile);
+  const extensionViolations = await evaluateGovernanceRulePacks(
+    extensionRegistry,
+    {
+      workspace: enrichedInventory,
+      profile: effectiveProfile,
+      context: {
+        workspaceRoot,
+        profileName,
+        options: { ...options },
+        snapshot,
+        inventory,
+      },
+    }
+  );
+  const allViolations = [...coreViolations, ...extensionViolations];
+  const graphSignals = buildGraphSignals(
+    toWorkspaceGraphSnapshot(enrichedInventory)
+  );
   const policySignals = buildPolicySignals(allViolations);
   const resolvedConformanceInput = resolveConformanceInput(
     options.conformanceJson
   );
   const conformanceSignals = loadConformanceSignals(resolvedConformanceInput);
-  const metricSignals = mergeGovernanceSignals(
+  const coreSignals = mergeGovernanceSignals(
     graphSignals,
     conformanceSignals,
     policySignals
   );
-  const allMeasurements = calculateMetrics({
-    workspace: inventory,
-    signals: metricSignals,
+  const extensionSignals = await collectGovernanceSignals(extensionRegistry, {
+    workspace: enrichedInventory,
+    profile: effectiveProfile,
+    violations: allViolations,
+    signals: coreSignals,
+    context: {
+      workspaceRoot,
+      profileName,
+      options: { ...options },
+      snapshot,
+      inventory,
+    },
   });
-  const allTopIssues = buildTopIssues(metricSignals);
+  const allSignals = mergeGovernanceSignals(coreSignals, extensionSignals);
+  const coreMeasurements = calculateMetrics({
+    workspace: enrichedInventory,
+    signals: allSignals,
+  });
+  const extensionMeasurements = await collectGovernanceMeasurements(
+    extensionRegistry,
+    {
+      workspace: enrichedInventory,
+      profile: effectiveProfile,
+      signals: allSignals,
+      measurements: coreMeasurements,
+      violations: allViolations,
+      context: {
+        workspaceRoot,
+        profileName,
+        options: { ...options },
+        snapshot,
+        inventory,
+      },
+    }
+  );
+  const allMeasurements = [...coreMeasurements, ...extensionMeasurements];
+  const allTopIssues = buildTopIssues(allSignals);
   const filteredMeasurements = filterMeasurements(
     allMeasurements,
     options.reportType
   );
   const filteredSignals = filterSignalsForReportType(
-    metricSignals,
+    allSignals,
     options.reportType
   );
   const filteredViolations = filterViolations(
@@ -1509,7 +1574,7 @@ async function buildAssessment(
   );
 
   return {
-    workspace: inventory,
+    workspace: enrichedInventory,
     profile: profileName,
     warnings: overrides.runtimeWarnings,
     violations: filteredViolations,
@@ -1519,7 +1584,7 @@ async function buildAssessment(
     topIssues: buildTopIssues(filteredSignals),
     health: calculateHealthScore(
       allMeasurements,
-      metricWeightsFromProfile(effectiveProfile.metrics),
+      effectiveProfile.metrics,
       effectiveProfile.health.statusThresholds,
       {
         topIssues: allTopIssues,
@@ -1554,46 +1619,20 @@ function toWorkspaceGraphSnapshot(
   };
 }
 
-function metricWeightsFromProfile(metrics: {
-  architecturalEntropyWeight: number;
-  dependencyComplexityWeight: number;
-  domainIntegrityWeight: number;
-  ownershipCoverageWeight: number;
-  documentationCompletenessWeight: number;
-  layerIntegrityWeight: number;
-}): MetricWeights {
-  return {
-    'architectural-entropy': metrics.architecturalEntropyWeight,
-    'dependency-complexity': metrics.dependencyComplexityWeight,
-    'domain-integrity': metrics.domainIntegrityWeight,
-    'ownership-coverage': metrics.ownershipCoverageWeight,
-    'documentation-completeness': metrics.documentationCompletenessWeight,
-    'layer-integrity': metrics.layerIntegrityWeight,
-  };
-}
-
 function filterViolations(
   violations: GovernanceAssessment['violations'],
   reportType: GovernanceRunOptions['reportType']
 ): GovernanceAssessment['violations'] {
   if (reportType === 'boundaries') {
-    return violations.filter(
-      (violation) =>
-        violation.ruleId === 'domain-boundary' ||
-        violation.ruleId === 'layer-boundary'
-    );
+    return violations.filter((violation) => violation.category === 'boundary');
   }
 
   if (reportType === 'ownership') {
-    return violations.filter(
-      (violation) => violation.ruleId === 'ownership-presence'
-    );
+    return violations.filter((violation) => violation.category === 'ownership');
   }
 
   if (reportType === 'architecture') {
-    return violations.filter(
-      (violation) => violation.ruleId !== 'ownership-presence'
-    );
+    return violations.filter((violation) => violation.category !== 'ownership');
   }
 
   return violations;
@@ -1604,30 +1643,40 @@ function filterMeasurements(
   reportType: GovernanceRunOptions['reportType']
 ): GovernanceAssessment['measurements'] {
   if (reportType === 'boundaries') {
-    return measurements.filter((measurement) =>
-      ['architectural-entropy', 'domain-integrity', 'layer-integrity'].includes(
-        measurement.id
-      )
+    return measurements.filter(
+      (measurement) => measurement.family === 'boundaries'
     );
   }
 
   if (reportType === 'ownership') {
     return measurements.filter(
-      (measurement) => measurement.id === 'ownership-coverage'
+      (measurement) => measurement.family === 'ownership'
     );
   }
 
   if (reportType === 'architecture') {
-    return measurements.filter((measurement) =>
-      [
-        'architectural-entropy',
-        'dependency-complexity',
-        'domain-integrity',
-      ].includes(measurement.id)
+    return measurements.filter(
+      (measurement) =>
+        measurement.family !== 'ownership' &&
+        measurement.family !== 'documentation'
     );
   }
 
   return measurements;
+}
+
+function normalizeMetricWeights(
+  metrics: Record<string, number | undefined> | undefined
+): GovernanceProfile['metrics'] {
+  if (!metrics) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(metrics).filter(
+      (entry): entry is [string, number] => typeof entry[1] === 'number'
+    )
+  );
 }
 
 function loadConformanceSignals(

--- a/packages/governance/src/policy-engine/evaluate-policies.ts
+++ b/packages/governance/src/policy-engine/evaluate-policies.ts
@@ -35,6 +35,7 @@ export function evaluatePolicies(
         ruleId: 'domain-boundary',
         project: source.name,
         severity: 'error',
+        category: 'boundary',
         message: `Project ${source.name} in domain ${source.domain} depends on ${target.name} in domain ${target.domain}.`,
         details: {
           targetProject: target.name,
@@ -60,6 +61,7 @@ export function evaluatePolicies(
         ruleId: 'layer-boundary',
         project: source.name,
         severity: 'warning',
+        category: 'boundary',
         message: `Layer violation: ${source.name} (${source.layer}) depends on ${target.name} (${target.layer}).`,
         details: {
           targetProject: target.name,
@@ -84,6 +86,7 @@ export function evaluatePolicies(
           ruleId: 'ownership-presence',
           project: project.name,
           severity: 'warning',
+          category: 'ownership',
           message: `Project ${project.name} has no ownership metadata or CODEOWNERS mapping.`,
           recommendation:
             'Add ownership metadata in project configuration or ensure CODEOWNERS covers the project root.',

--- a/packages/governance/src/presets/angular-cleanup/profile.ts
+++ b/packages/governance/src/presets/angular-cleanup/profile.ts
@@ -6,8 +6,18 @@ import {
   DEFAULT_HEALTH_STATUS_THRESHOLDS,
   GovernanceProfile,
   HealthStatusThresholds,
+  Measurement,
   ProfileOverrides,
 } from '../../core/index.js';
+
+const LEGACY_PROFILE_METRIC_KEY_MAP = {
+  architecturalEntropyWeight: 'architectural-entropy',
+  dependencyComplexityWeight: 'dependency-complexity',
+  domainIntegrityWeight: 'domain-integrity',
+  ownershipCoverageWeight: 'ownership-coverage',
+  documentationCompletenessWeight: 'documentation-completeness',
+  layerIntegrityWeight: 'layer-integrity',
+} as const;
 
 export const angularCleanupProfile: GovernanceProfile = {
   name: 'angular-cleanup',
@@ -25,12 +35,12 @@ export const angularCleanupProfile: GovernanceProfile = {
     statusThresholds: DEFAULT_HEALTH_STATUS_THRESHOLDS,
   },
   metrics: {
-    architecturalEntropyWeight: 0.2,
-    dependencyComplexityWeight: 0.2,
-    domainIntegrityWeight: 0.2,
-    ownershipCoverageWeight: 0.2,
-    documentationCompletenessWeight: 0.2,
-    layerIntegrityWeight: 0.2,
+    'architectural-entropy': 0.2,
+    'dependency-complexity': 0.2,
+    'domain-integrity': 0.2,
+    'ownership-coverage': 0.2,
+    'documentation-completeness': 0.2,
+    'layer-integrity': 0.2,
   },
 };
 
@@ -68,7 +78,7 @@ export async function loadProfileOverrides(
     allowedDomainDependencies?: Record<string, string[]>;
     ownership?: ProfileOverrides['ownership'];
     health?: ProfileOverrides['health'];
-    metrics?: Partial<GovernanceProfile['metrics']>;
+    metrics?: Record<string, number>;
     projectOverrides?: ProfileOverrides['projectOverrides'];
   };
 
@@ -109,11 +119,36 @@ export async function loadProfileOverrides(
     },
     metrics: {
       ...angularCleanupProfile.metrics,
-      ...(raw.metrics ?? {}),
+      ...normalizeMetricWeights(raw.metrics),
     },
     projectOverrides: raw.projectOverrides ?? {},
     runtimeWarnings,
   };
+}
+
+function normalizeMetricWeights(
+  raw: Record<string, number> | undefined
+): Record<Measurement['id'], number> {
+  if (!raw) {
+    return {};
+  }
+
+  const normalized: Record<string, number> = {};
+
+  for (const [key, value] of Object.entries(raw)) {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      continue;
+    }
+
+    const normalizedKey =
+      LEGACY_PROFILE_METRIC_KEY_MAP[
+        key as keyof typeof LEGACY_PROFILE_METRIC_KEY_MAP
+      ] ?? key;
+
+    normalized[normalizedKey] = value;
+  }
+
+  return normalized;
 }
 
 async function loadAllowedDomainDependenciesFromEslint(

--- a/packages/governance/src/reporting/metric-breakdown.spec.ts
+++ b/packages/governance/src/reporting/metric-breakdown.spec.ts
@@ -20,7 +20,7 @@ describe('metric breakdown helpers', () => {
     expect(breakdown.families).toEqual([
       {
         family: 'architecture',
-        score: 83,
+        score: 78,
         measurements: [
           measurementSummary(
             'architectural-entropy',
@@ -32,19 +32,12 @@ describe('metric breakdown helpers', () => {
             'Dependency Complexity',
             89
           ),
-          measurementSummary('domain-integrity', 'Domain Integrity', 100),
-          measurementSummary('layer-integrity', 'Layer Integrity', 78),
         ],
       },
       {
         family: 'boundaries',
-        score: 81,
+        score: 89,
         measurements: [
-          measurementSummary(
-            'architectural-entropy',
-            'Architectural Entropy',
-            66
-          ),
           measurementSummary('domain-integrity', 'Domain Integrity', 100),
           measurementSummary('layer-integrity', 'Layer Integrity', 78),
         ],
@@ -97,11 +90,28 @@ function measurement(
   return {
     id,
     name,
+    family: familyForMeasurement(id),
     value: score / 100,
     score,
     maxScore: 100,
     unit: 'ratio',
   };
+}
+
+function familyForMeasurement(id: Measurement['id']): Measurement['family'] {
+  if (id === 'ownership-coverage') {
+    return 'ownership';
+  }
+
+  if (id === 'documentation-completeness') {
+    return 'documentation';
+  }
+
+  if (id === 'domain-integrity' || id === 'layer-integrity') {
+    return 'boundaries';
+  }
+
+  return 'architecture';
 }
 
 function measurementSummary(

--- a/packages/governance/src/reporting/metric-breakdown.ts
+++ b/packages/governance/src/reporting/metric-breakdown.ts
@@ -11,33 +11,27 @@ const FAMILY_ORDER: GovernanceMetricFamily[] = [
   'documentation',
 ];
 
-const FAMILY_MEASUREMENT_IDS: Record<
-  GovernanceMetricFamily,
-  Measurement['id'][]
-> = {
-  architecture: [
-    'architectural-entropy',
-    'dependency-complexity',
-    'domain-integrity',
-    'layer-integrity',
-  ],
-  boundaries: ['architectural-entropy', 'domain-integrity', 'layer-integrity'],
-  ownership: ['ownership-coverage'],
-  documentation: ['documentation-completeness'],
-};
-
 export function buildMetricBreakdown(
   measurements: Measurement[]
 ): MetricBreakdown {
-  const measurementsById = new Map(
-    measurements.map((measurement) => [measurement.id, measurement] as const)
+  const measurementsByFamily = new Map<GovernanceMetricFamily, Measurement[]>();
+
+  for (const measurement of measurements) {
+    const existing = measurementsByFamily.get(measurement.family) ?? [];
+    existing.push(measurement);
+    measurementsByFamily.set(measurement.family, existing);
+  }
+
+  const orderedFamilies = sortKnownThenAlphabetical(
+    [...measurementsByFamily.keys()],
+    FAMILY_ORDER
   );
 
   return {
-    families: FAMILY_ORDER.flatMap((family) => {
-      const familyMeasurements = FAMILY_MEASUREMENT_IDS[family]
-        .map((id) => measurementsById.get(id))
-        .filter((measurement): measurement is Measurement => !!measurement)
+    families: orderedFamilies.flatMap((family) => {
+      const familyMeasurements = (measurementsByFamily.get(family) ?? [])
+        .slice()
+        .sort((a, b) => a.id.localeCompare(b.id))
         .map((measurement) => ({
           id: measurement.id,
           name: measurement.name,
@@ -63,4 +57,17 @@ export function buildMetricBreakdown(
       ];
     }),
   };
+}
+
+function sortKnownThenAlphabetical<T extends string>(
+  values: T[],
+  knownOrder: readonly T[]
+): T[] {
+  const seen = new Set(values);
+  const orderedKnown = knownOrder.filter((value) => seen.has(value));
+  const orderedExtras = values
+    .filter((value) => !knownOrder.includes(value))
+    .sort((a, b) => a.localeCompare(b));
+
+  return [...orderedKnown, ...orderedExtras];
 }

--- a/packages/governance/src/reporting/signal-breakdown.spec.ts
+++ b/packages/governance/src/reporting/signal-breakdown.spec.ts
@@ -44,6 +44,7 @@ describe('signal breakdown helpers', () => {
         { source: 'graph', count: 2 },
         { source: 'conformance', count: 1 },
         { source: 'policy', count: 1 },
+        { source: 'extension', count: 0 },
       ],
       byType: [
         { type: 'structural-dependency', count: 1 },
@@ -76,6 +77,7 @@ describe('signal breakdown helpers', () => {
         { source: 'graph', count: 1 },
         { source: 'conformance', count: 0 },
         { source: 'policy', count: 0 },
+        { source: 'extension', count: 0 },
       ],
       byType: [{ type: 'structural-dependency', count: 1 }],
       bySeverity: [

--- a/packages/governance/src/reporting/signal-breakdown.ts
+++ b/packages/governance/src/reporting/signal-breakdown.ts
@@ -1,7 +1,9 @@
 import type { SignalBreakdown } from '../core/index.js';
 import type {
   GovernanceSignal,
+  GovernanceSignalSource,
   GovernanceSignalSeverity,
+  KnownGovernanceSignalType,
   GovernanceSignalType,
 } from '../signal-engine/index.js';
 
@@ -11,9 +13,14 @@ export type GovernanceReportType =
   | 'ownership'
   | 'architecture';
 
-const SOURCE_ORDER = ['graph', 'conformance', 'policy'] as const;
+const SOURCE_ORDER: GovernanceSignalSource[] = [
+  'graph',
+  'conformance',
+  'policy',
+  'extension',
+];
 const SEVERITY_ORDER: GovernanceSignalSeverity[] = ['info', 'warning', 'error'];
-const TYPE_ORDER: GovernanceSignalType[] = [
+const TYPE_ORDER: KnownGovernanceSignalType[] = [
   'structural-dependency',
   'cross-domain-dependency',
   'missing-domain-context',
@@ -61,11 +68,25 @@ export function buildSignalBreakdown(
 
   return {
     total: signals.length,
-    bySource: SOURCE_ORDER.map((source) => ({
-      source,
-      count: sourceCounts.get(source) ?? 0,
-    })),
-    byType: TYPE_ORDER.flatMap((type) => {
+    bySource: [
+      ...SOURCE_ORDER.map((source) => ({
+        source,
+        count: sourceCounts.get(source) ?? 0,
+      })),
+      ...sortKnownThenAlphabetical<GovernanceSignalSource>(
+        [...sourceCounts.keys()] as GovernanceSignalSource[],
+        SOURCE_ORDER
+      )
+        .filter((source) => !SOURCE_ORDER.includes(source))
+        .map((source) => ({
+          source,
+          count: sourceCounts.get(source) ?? 0,
+        })),
+    ],
+    byType: sortKnownThenAlphabetical(
+      [...typeCounts.keys()],
+      TYPE_ORDER
+    ).flatMap((type) => {
       const count = typeCounts.get(type) ?? 0;
 
       return count > 0 ? [{ type, count }] : [];
@@ -75,4 +96,17 @@ export function buildSignalBreakdown(
       count: severityCounts.get(severity) ?? 0,
     })),
   };
+}
+
+function sortKnownThenAlphabetical<T extends string>(
+  values: T[],
+  knownOrder: readonly T[]
+): T[] {
+  const seen = new Set(values);
+  const orderedKnown = knownOrder.filter((value) => seen.has(value));
+  const orderedExtras = values
+    .filter((value) => !knownOrder.includes(value))
+    .sort((a, b) => a.localeCompare(b));
+
+  return [...orderedKnown, ...orderedExtras];
 }

--- a/packages/governance/src/reporting/top-issues.ts
+++ b/packages/governance/src/reporting/top-issues.ts
@@ -3,16 +3,17 @@ import type {
   GovernanceSignal,
   GovernanceSignalSeverity,
   GovernanceSignalSource,
-  GovernanceSignalType,
+  KnownGovernanceSignalType,
 } from '../signal-engine/index.js';
 
 const SOURCE_ORDER: Record<GovernanceSignalSource, number> = {
   graph: 0,
   conformance: 1,
   policy: 2,
+  extension: 3,
 };
 
-const TYPE_ORDER: Record<GovernanceSignalType, number> = {
+const TYPE_ORDER: Record<KnownGovernanceSignalType, number> = {
   'structural-dependency': 0,
   'cross-domain-dependency': 1,
   'missing-domain-context': 2,
@@ -48,6 +49,9 @@ export function buildTopIssues(
       if (!existing.issue.ruleId) {
         existing.issue.ruleId = readRuleId(signal);
       }
+      if (!existing.issue.sourcePluginId) {
+        existing.issue.sourcePluginId = signal.sourcePluginId;
+      }
       continue;
     }
 
@@ -60,6 +64,7 @@ export function buildTopIssues(
         projects: projectsFromSignal(signal),
         ruleId: readRuleId(signal),
         message: signal.message,
+        sourcePluginId: signal.sourcePluginId,
       },
     });
   }
@@ -120,9 +125,22 @@ function compareTopIssues(
     return countOrder;
   }
 
-  const typeOrder = TYPE_ORDER[a.type] - TYPE_ORDER[b.type];
-  if (typeOrder !== 0) {
+  const knownTypeOrderA = TYPE_ORDER[a.type as KnownGovernanceSignalType];
+  const knownTypeOrderB = TYPE_ORDER[b.type as KnownGovernanceSignalType];
+  const typeOrder = knownTypeOrderA - knownTypeOrderB;
+  if (
+    knownTypeOrderA !== undefined &&
+    knownTypeOrderB !== undefined &&
+    typeOrder !== 0
+  ) {
     return typeOrder;
+  }
+
+  if (!(a.type in TYPE_ORDER) || !(b.type in TYPE_ORDER)) {
+    const dynamicTypeOrder = a.type.localeCompare(b.type);
+    if (dynamicTypeOrder !== 0) {
+      return dynamicTypeOrder;
+    }
   }
 
   const sourceOrder = SOURCE_ORDER[a.source] - SOURCE_ORDER[b.source];

--- a/packages/governance/src/signal-engine/builders.ts
+++ b/packages/governance/src/signal-engine/builders.ts
@@ -29,6 +29,7 @@ interface SignalDraft {
   message: string;
   metadata?: Record<string, unknown>;
   source: GovernanceSignalSource;
+  sourcePluginId?: string;
   createdAt: string;
   identityKey?: string;
 }
@@ -38,6 +39,7 @@ const SOURCE_SORT_ORDER: Record<GovernanceSignalSource, number> = {
   graph: 0,
   conformance: 1,
   policy: 2,
+  extension: 3,
 };
 const SEVERITY_SORT_ORDER: Record<GovernanceSignalSeverity, number> = {
   info: 0,
@@ -235,6 +237,7 @@ function mapViolationToPolicySignal(
       message: violation.message,
       metadata,
       source: 'policy',
+      sourcePluginId: violation.sourcePluginId,
       createdAt,
       identityKey: [
         'policy',
@@ -279,6 +282,7 @@ function finalizeSignal(draft: SignalDraft): GovernanceSignal {
     message: draft.message,
     metadata,
     source: draft.source,
+    sourcePluginId: draft.sourcePluginId,
     createdAt: draft.createdAt,
   };
 }

--- a/packages/governance/src/signal-engine/index.ts
+++ b/packages/governance/src/signal-engine/index.ts
@@ -3,6 +3,7 @@ export type {
   GovernanceSignalCategory,
   GovernanceSignalSeverity,
   GovernanceSignalSource,
+  KnownGovernanceSignalType,
   GovernanceSignalType,
 } from './types.js';
 export {

--- a/packages/governance/src/signal-engine/types.ts
+++ b/packages/governance/src/signal-engine/types.ts
@@ -1,6 +1,8 @@
 import type { Category } from '../conformance-adapter/conformance-adapter.js';
 
-export type GovernanceSignalType =
+export type GovernanceSignalType = KnownGovernanceSignalType | (string & {});
+
+export type KnownGovernanceSignalType =
   | 'structural-dependency'
   | 'cross-domain-dependency'
   | 'missing-domain-context'
@@ -14,7 +16,11 @@ export type GovernanceSignalSeverity = 'info' | 'warning' | 'error';
 
 export type GovernanceSignalCategory = Category | 'structure';
 
-export type GovernanceSignalSource = 'graph' | 'conformance' | 'policy';
+export type GovernanceSignalSource =
+  | 'graph'
+  | 'conformance'
+  | 'policy'
+  | 'extension';
 
 export interface GovernanceSignal {
   id: string;
@@ -27,5 +33,6 @@ export interface GovernanceSignal {
   message: string;
   metadata?: Record<string, unknown>;
   source: GovernanceSignalSource;
+  sourcePluginId?: string;
   createdAt: string;
 }


### PR DESCRIPTION
Promote the governance extension host to a public typed contract surface and wire extension enrichers, rule packs, signal providers, and metric providers into the governance assessment pipeline.

This also generalizes shared governance models so extension violations, signals, and metrics flow through existing health scoring and reporting, while preserving compatibility with legacy profile metric keys.

Closes #62 Refs #41