### PR TITLE
docs(nx-governance): document extension model and plugin boundaries

### DIFF
--- a/packages/governance/ARCHITECTURE.md
+++ b/packages/governance/ARCHITECTURE.md
@@ -1,301 +1,154 @@
-# Nx Governance Architecture (Augmented v2)
+# Nx Governance Architecture
 
 ## 1. Purpose
 
-Nx Governance is a **deterministic governance and health analysis plugin** for Nx workspaces.
+`@anarchitects/nx-governance` is the shared governance core for Nx workspaces.
 
-It analyzes:
-- repository structure
-- project boundaries
-- architectural consistency
-- drift over time
+It turns workspace structure into:
 
-It produces:
-- metrics
-- health scores
-- findings
-- recommendations
-- AI-ready payloads
+- governance signals
+- weighted health scores
+- explainable findings
+- CLI and JSON reports
+- snapshot and AI payload inputs
 
----
+The core is intentionally ecosystem-neutral. Framework- and language-specific intelligence should live in separate extension plugins that contribute into the shared governance pipeline.
 
-## 2. Strategic Positioning
+## 2. Product model
 
-Nx Governance is an **interpretation layer on top of Nx signals**.
+The intended architecture is:
 
-It does NOT:
-- replace Nx Graph
-- replace Nx Conformance
-- enforce rules
+- one shared core plugin: `@anarchitects/nx-governance`
+- multiple ecosystem-specific extension plugins such as `@anarchitects/nx-governance-angular`
 
-It DOES:
-- interpret structural signals (Nx Graph)
-- interpret compliance signals (Nx Conformance — upcoming)
-- aggregate signals into health and insights
+This keeps generic governance concerns in one place and prevents the core package from accumulating Angular-, React-, JVM-, or .NET-specific runtime logic.
 
-### Evolution Path
+### Generic governance concerns
 
-Today:
-- Nx Graph + profile policy → metrics → health → reporting
+These stay in the core package:
 
-Next:
-- Nx Graph → GraphAdapter
-- Nx Conformance → ConformanceAdapter
-- Signals → GovernanceSignal → metrics → health
+- Nx graph loading and workspace normalization
+- dependency and boundary analysis
+- ownership and documentation checks
+- signal aggregation
+- metric calculation and health scoring
+- CLI and JSON reporting
+- snapshot and AI payload generation
+- extension discovery and execution lifecycle
 
-Future:
-- Multi-workspace (PolyGraph)
-- Org-level insights
-- Cross-repo governance
+### Ecosystem-specific manifestations
 
----
+These belong in extension plugins:
 
-## 3. Current Module Structure
+- framework-specific layering conventions
+- ecosystem-specific dependency smells
+- metadata extraction and enrichers
+- rule packs and heuristics
+- extension-specific metrics and signals
 
-Located under:
+## 3. Core vs extension responsibilities
 
+The core owns:
+
+- the governance execution lifecycle
+- shared data contracts
+- scoring and score aggregation
+- reporting and machine-readable outputs
+- extension registration and ordering
+
+Extensions own:
+
+- workspace enrichers
+- rule packs
+- signal providers
+- metric providers
+- optional presets and extension-specific docs
+
+Extensions contribute intelligence. The core remains the place where that intelligence is collected, scored, and reported.
+
+## 4. Extension model
+
+Governance-capable Nx plugins are discovered from `nx.json.plugins`.
+
+If a plugin wants to extend governance, it should expose:
+
+```text
+<package>/governance-extension
 ```
+
+That module must export a named `governanceExtension`.
+
+The public extension-facing contracts are exported from the package root:
+
+- `GovernanceExtensionDefinition`
+- `GovernanceExtensionHostContext`
+- `GovernanceExtensionHost`
+- `GovernanceWorkspaceEnricher`
+- `GovernanceRulePack`
+- `GovernanceSignalProvider`
+- `GovernanceMetricProvider`
+
+Extensions reuse the shared governance output types:
+
+- `GovernanceSignal`
+- `Violation`
+- `Measurement`
+
+For the authoring view and example code, see [EXTENSIONS.md](./EXTENSIONS.md).
+
+## 5. Execution flow
+
+The core runtime owns the full orchestration pipeline:
+
+```text
+runGovernance
+  -> load profile and Nx snapshot
+  -> build normalized governance workspace
+  -> discover and register governance extensions
+  -> apply workspace enrichers
+  -> evaluate core policies and extension rule packs
+  -> merge core and extension signals
+  -> merge core and extension metrics
+  -> calculate health and top issues
+  -> render reports, snapshots, and AI payloads
+```
+
+This preserves one governance truth even when multiple ecosystem engines contribute analysis.
+
+## 6. Module structure
+
+The core package lives under:
+
+```text
 packages/governance/src
 ```
 
-Main modules:
+The main architectural areas are:
 
-- core → orchestration (runGovernance)
-- inventory → project and structure extraction
-- metrics → metric calculations
-- health → scoring system
-- reporting → CLI output
-- snapshot → persistence and drift
-- ai → payload generation
-- config → profile configuration
+- `plugin` for orchestration and executor entrypoints
+- `inventory` and `nx-adapter` for workspace normalization
+- `policy-engine`, `signal-engine`, and `metrics` for shared governance evaluation
+- `health` and `reporting` for score aggregation and output
+- `snapshot` and `ai` for downstream consumption
+- `extensions` for extension discovery, registration, and public contracts
 
----
+## 7. Angular as the reference extension
 
-## 4. Main Execution Flow
+Angular is the first reference ecosystem engine, but it should not be embedded directly into the core package.
 
-```
-runGovernance
-    ↓
-Inventory Builder (Nx Graph)
-    ↓
-Metrics Engine
-    ↓
-Health Engine
-    ↓
-Reporting Engine
-    ↓
-Snapshot Engine
-    ↓
-AI Payload Generation
-```
+The intended package model is:
 
-### Characteristics
+- `@anarchitects/nx-governance` as the shared platform
+- `@anarchitects/nx-governance-angular` as the Angular extension plugin
 
-- deterministic pipeline
-- no side effects
-- CLI-first
-- composable steps
+The Angular plugin should contribute Angular-specific metrics, signals, rule packs, and metadata enrichers through the shared contracts. It should not duplicate the governance model, scoring pipeline, or reporting infrastructure.
 
----
+This establishes the reference pattern for future engines such as TypeScript, React, Maven, Gradle, and .NET.
 
-## 5. Core Models and Contracts
+## 8. Guiding principles
 
-### WorkspaceInventory
-
-Represents normalized workspace structure.
-
-Contains:
-- projects
-- dependencies
-- metadata
-
----
-
-### Metrics
-
-Computed indicators based on inventory.
-
-Examples:
-- boundary integrity
-- dependency complexity
-- ownership coverage
-
----
-
-### Health Score
-
-Aggregated score derived from metrics.
-
-Used for:
-- summaries
-- trend tracking
-- decision support
-
----
-
-### Snapshot
-
-Serialized output of a run.
-
-Used for:
-- drift detection
-- historical comparison
-
----
-
-### AI Payload
-
-Structured JSON containing:
-- metrics
-- findings
-- recommendations
-
-Used by external AI agents.
-
----
-
-## 6. CLI Surface
-
-Commands:
-
-- run governance analysis
-- output results
-- generate snapshot
-- generate AI payload
-
-Targets:
-- explicit targets only (current limitation)
-
----
-
-## 7. Reporting & Snapshot Flow
-
-Reporting:
-- CLI output (human-readable)
-- structured JSON (machine-readable)
-
-Snapshots:
-- stored for drift comparison
-- enable time-based analysis
-
----
-
-## 8. AI Flow (Model 1)
-
-Nx Governance does NOT execute AI.
-
-Instead:
-- generates payloads
-- suggests prompts
-
-AI execution happens in:
-- VS Code
-- Cursor
-- external tools
-
----
-
-## 9. Architectural Principles
-
-- deterministic first
-- no hidden behavior
-- modular design
-- no tight Nx coupling
-- extensible pipeline
-- explicit over implicit
-
----
-
-## 10. Known Gaps (Current State)
-
-- no GraphAdapter abstraction yet
-- no Conformance integration yet
-- no unified signal model
-- no inferred targets
-- AI payload coverage limited
-
----
-
-## 11. Target Architecture Delta
-
-### Current State
-
-```
-Nx Graph + Profile Policy
-    ↓
-Inventory
-    ↓
-Metrics
-    ↓
-Health
-    ↓
-Reporting
-```
-
----
-
-### Target State
-
-```
-Nx Graph → GraphAdapter
-Nx Conformance → ConformanceAdapter
-
-Graph + Conformance
-    ↓
-GovernanceSignal (unified model)
-    ↓
-Metrics Engine
-    ↓
-Health Engine
-    ↓
-Reporting / Snapshot / AI
-```
-
----
-
-## 12. Planned Extensions
-
-### GraphAdapter
-- normalize Nx graph
-- decouple Nx internals
-
-### ConformanceAdapter
-- ingest rule violations
-- convert to signals
-
-### GovernanceSignal
-- unified signal abstraction
-- source-aware (graph / conformance)
-
----
-
-## 13. AI Agent Working Context
-
-When extending this system:
-
-### DO
-
-- extend existing pipeline
-- use adapters as isolation layers
-- keep logic deterministic
-- reuse core models
-- keep AI external
-
-### DO NOT
-
-- redesign the architecture
-- duplicate Nx features
-- tightly couple to Nx APIs
-- introduce implicit behavior
-
----
-
-## 14. Guiding Principle
-
-Nx Governance:
-
-- reads signals
-- interprets signals
-- enables decisions
-
-It does not enforce or replace Nx.
+- keep the core deterministic
+- keep ecosystem logic out of the core package
+- extend the shared pipeline instead of forking it
+- preserve a single scoring and reporting model
+- keep outputs explainable and traceable back to contributed signals, violations, and metrics

--- a/packages/governance/EXTENSIONS.md
+++ b/packages/governance/EXTENSIONS.md
@@ -1,0 +1,139 @@
+# Nx Governance Extensions
+
+This document describes the extension model for `@anarchitects/nx-governance`.
+
+The product architecture is:
+
+- one shared core Nx plugin: `@anarchitects/nx-governance`
+- multiple ecosystem-specific extension plugins such as `@anarchitects/nx-governance-angular`
+
+The core owns governance orchestration, scoring, reporting, and shared data contracts. Extension plugins contribute ecosystem-specific intelligence into that shared pipeline.
+
+## Core vs extension responsibilities
+
+The core plugin owns:
+
+- Nx workspace graph loading and normalization
+- governance execution lifecycle
+- shared governance models such as `GovernanceSignal`, `Violation`, and `Measurement`
+- health scoring and score aggregation
+- CLI and JSON reporting
+- extension discovery and registration
+
+Extension plugins own:
+
+- workspace enrichers
+- rule packs
+- signal providers
+- metric providers
+- optional presets and extension-specific documentation
+
+Extensions contribute inputs into the governance pipeline. They do not replace core scoring, reporting, or output formats.
+
+## Discovery convention
+
+Governance-capable Nx plugins are discovered from `nx.json.plugins`.
+
+If a plugin wants to participate in governance, it should expose a subpath entrypoint at:
+
+```text
+<package>/governance-extension
+```
+
+That module must export a named `governanceExtension` value.
+
+## Public authoring contracts
+
+The core package exports the extension-facing contracts from the package root:
+
+- `GovernanceExtensionDefinition`
+- `GovernanceExtensionHostContext`
+- `GovernanceExtensionHost`
+- `GovernanceWorkspaceEnricher`
+- `GovernanceRulePack`
+- `GovernanceSignalProvider`
+- `GovernanceMetricProvider`
+
+Extensions should reuse the shared governance output types:
+
+- `GovernanceSignal`
+- `Violation`
+- `Measurement`
+
+## Execution lifecycle
+
+At runtime, the core pipeline executes in this order:
+
+1. Load the governance profile and Nx workspace snapshot.
+2. Build the normalized governance workspace inventory.
+3. Discover governance extensions from `nx.json.plugins`.
+4. Register enrichers, rule packs, signal providers, and metric providers.
+5. Apply enrichers to the workspace inventory.
+6. Evaluate core policies and extension rule packs.
+7. Build core signals and collect extension signals.
+8. Build core metrics and collect extension metrics.
+9. Aggregate health, render reports, and produce JSON output.
+
+This preserves a single governance truth while allowing ecosystem-specific analysis.
+
+## Minimal extension example
+
+```ts
+import type {
+  GovernanceExtensionDefinition,
+  GovernanceMetricProvider,
+  GovernanceRulePack,
+  GovernanceSignalProvider,
+  GovernanceWorkspaceEnricher,
+} from '@anarchitects/nx-governance';
+
+const angularEnricher: GovernanceWorkspaceEnricher = {
+  enrichWorkspace({ workspace }) {
+    return workspace;
+  },
+};
+
+const angularRules: GovernanceRulePack = {
+  evaluate() {
+    return [];
+  },
+};
+
+const angularSignals: GovernanceSignalProvider = {
+  provideSignals() {
+    return [];
+  },
+};
+
+const angularMetrics: GovernanceMetricProvider = {
+  provideMetrics() {
+    return [];
+  },
+};
+
+export const governanceExtension: GovernanceExtensionDefinition = {
+  id: '@anarchitects/nx-governance-angular',
+  register(host) {
+    host.registerEnricher(angularEnricher);
+    host.registerRulePack(angularRules);
+    host.registerSignalProvider(angularSignals);
+    host.registerMetricProvider(angularMetrics);
+  },
+};
+```
+
+## Angular as the reference extension
+
+The Angular engine is intended to be implemented as a separate package:
+
+- `@anarchitects/nx-governance-angular`
+
+That package is the reference model for future ecosystem engines such as:
+
+- TypeScript
+- React
+- Maven
+- Gradle
+- .NET
+
+The Angular plugin should contribute Angular-specific metrics, signals, rule packs, and metadata enrichers through the core contracts. It should not duplicate governance scoring or reporting infrastructure.

--- a/packages/governance/README.md
+++ b/packages/governance/README.md
@@ -17,6 +17,7 @@ Large Nx monorepos accumulate structural debt silently: cross-domain imports sli
 - [Installation](#installation)
 - [Supported Nx versions](#supported-nx-versions)
 - [Quick start](#quick-start)
+- [Extension model](#extension-model)
 - [Concepts](#concepts)
   - [Profiles](#profiles)
   - [Boundary policy source](#boundary-policy-source)
@@ -109,13 +110,37 @@ nx repo-architecture
 
 ---
 
+## Extension model
+
+`@anarchitects/nx-governance` is the shared governance core for Nx workspaces.
+
+The core package owns:
+
+- governance orchestration
+- shared governance models
+- scoring and health aggregation
+- CLI and JSON reporting
+- extension discovery and lifecycle
+
+Ecosystem-specific intelligence can be added through separate Nx plugins. Those plugins contribute enrichers, rule packs, signals, and metrics into the core pipeline instead of creating their own governance model.
+
+The first reference engine is Angular, positioned as a separate plugin:
+
+- `@anarchitects/nx-governance-angular`
+
+That keeps framework-specific behavior out of the core package and establishes the model for future engines such as TypeScript, React, Maven, Gradle, and .NET.
+
+If you are building an ecosystem plugin, see [EXTENSIONS.md](./EXTENSIONS.md).
+
+---
+
 ## Concepts
 
 ### Profiles
 
 A **governance profile** is a JSON file at `tools/governance/profiles/<name>.json`. It is the single source of truth for what the workspace architecture _should_ look like. Every run of any governance executor reads this file and evaluates the live project graph against it.
 
-The built-in preset is `angular-cleanup`, modelled on Angular workspace conventions (layered architecture, domain-driven boundaries). You can adjust every aspect of it by editing the JSON file — no TypeScript required.
+The built-in preset is `angular-cleanup`, a starter profile modelled on layered, domain-driven workspace conventions. It is a profile shipped by the core package, not an Angular engine implementation. You can adjust every aspect of it by editing the JSON file — no TypeScript required.
 
 ### Boundary policy source
 

--- a/packages/governance/ROADMAP.md
+++ b/packages/governance/ROADMAP.md
@@ -10,8 +10,10 @@
 This roadmap prioritizes **Nx ecosystem alignment** over Angular-specific expansion.
 
 Goal:
+
 - Become **complementary to Nx PowerPack (Conformance)** and **Nx Graph / PolyGraph**
 - Build a **signal-driven governance engine**
+- Establish `@anarchitects/nx-governance` as the shared core plugin for future ecosystem-specific governance extensions
 
 ---
 
@@ -122,21 +124,27 @@ Goal:
 
 ---
 
-# 🅰️ Phase 5 — Angular Specialization (LATER)
+# 🧩 Phase 5 — Ecosystem Extension Plugins (LATER)
 
-## Angular Metrics
+## Core Extension Model
 
-- [ ] Facade Bypass Ratio
-- [ ] Smart Component Density
-- [ ] Shared UI Coupling
-- [ ] Standalone Component Complexity
-- [ ] Module Boundary Violations
+- [x] Define extension registration and lifecycle in the core plugin
+- [x] Export extension authoring contracts from `@anarchitects/nx-governance`
+- [ ] Document extension packaging and authoring model
 
-## Angular Profile
+## Angular Reference Plugin
 
-- [ ] Implement Angular preset
-- [ ] Apply Angular-specific policies
-- [ ] Add Angular Architecture Score
+- [ ] Implement `@anarchitects/nx-governance-angular`
+- [ ] Add Angular-specific enrichers, rule packs, signals, and metrics
+- [ ] Ship Angular plugin docs and adoption guidance
+
+## Future Ecosystem Engines
+
+- [ ] TypeScript extension plugin
+- [ ] React extension plugin
+- [ ] Maven extension plugin
+- [ ] Gradle extension plugin
+- [ ] .NET extension plugin
 
 ---
 
@@ -157,10 +165,12 @@ Nx Governance builds on:
 - Nx Cloud / PolyGraph (future)
 
 It does NOT:
+
 - replace Nx features
 - duplicate rule engines
 
 It DOES:
+
 - interpret signals
 - provide health insights
 - enable architectural decision-making


### PR DESCRIPTION
Add dedicated extension authoring guidance for nx-governance and align the README, architecture, and roadmap with the core-plus-extensions plugin model.

This documents the public extension contracts, the `<package>/governance-extension` convention, and repositions Angular as the first reference extension plugin rather than a core specialization.

Closes #63 Refs #41 Refs #42