### PR TITLE
feat(nx-governance): add governance graph document contract and builder

### DIFF
--- a/packages/governance/src/core/exceptions.spec.ts
+++ b/packages/governance/src/core/exceptions.spec.ts
@@ -1,0 +1,278 @@
+import {
+  buildGovernanceExceptionScopeKey,
+  isConformanceExceptionScope,
+  isPolicyExceptionScope,
+  normalizeGovernanceException,
+} from './exceptions.js';
+
+describe('governance exception contract', () => {
+  it('normalizes a policy exception with target scope', () => {
+    const exception = normalizeGovernanceException({
+      id: '  billing-domain-waiver  ',
+      source: 'policy',
+      scope: {
+        source: 'policy',
+        ruleId: ' domain-boundary ',
+        projectId: ' billing-feature ',
+        targetProjectId: ' shared-util ',
+      },
+      reason: '  Transitional boundary while extracting an API. ',
+      owner: ' @org/architecture ',
+      review: {
+        createdAt: ' 2026-04-17 ',
+        reviewBy: ' 2026-06-01 ',
+      },
+    });
+
+    expect(exception).toEqual({
+      id: 'billing-domain-waiver',
+      source: 'policy',
+      scope: {
+        source: 'policy',
+        ruleId: 'domain-boundary',
+        projectId: 'billing-feature',
+        targetProjectId: 'shared-util',
+      },
+      reason: 'Transitional boundary while extracting an API.',
+      owner: '@org/architecture',
+      review: {
+        createdAt: '2026-04-17',
+        reviewBy: '2026-06-01',
+      },
+    });
+  });
+
+  it('normalizes a policy exception without target project', () => {
+    const exception = normalizeGovernanceException({
+      id: 'ownership-gap',
+      source: 'policy',
+      scope: {
+        source: 'policy',
+        ruleId: 'ownership-presence',
+        projectId: 'billing-api',
+      },
+      reason: 'Pending team split.',
+      owner: '@org/platform',
+      review: {
+        expiresAt: '2026-08-01',
+      },
+    });
+
+    expect(exception.scope).toEqual({
+      source: 'policy',
+      ruleId: 'ownership-presence',
+      projectId: 'billing-api',
+    });
+  });
+
+  it('normalizes conformance related projects deterministically', () => {
+    const exception = normalizeGovernanceException({
+      id: 'conformance-waiver',
+      source: 'conformance',
+      scope: {
+        source: 'conformance',
+        ruleId: 'enforce-module-boundaries',
+        relatedProjectIds: ['payments-lib', 'checkout-app', 'payments-lib', '  '],
+      },
+      reason: 'Known migration overlap.',
+      owner: '@org/architecture',
+      review: {
+        reviewBy: '2026-05-15',
+      },
+    });
+
+    expect(exception.scope).toEqual({
+      source: 'conformance',
+      ruleId: 'enforce-module-boundaries',
+      relatedProjectIds: ['checkout-app', 'payments-lib'],
+    });
+  });
+
+  it('supports conformance scope keyed by category and project', () => {
+    const exception = normalizeGovernanceException({
+      id: 'conformance-category-waiver',
+      source: 'conformance',
+      scope: {
+        source: 'conformance',
+        category: 'boundary',
+        projectId: 'checkout-app',
+      },
+      reason: 'Rule identifier not stable yet.',
+      owner: '@org/architecture',
+      review: {
+        expiresAt: '2026-07-01',
+      },
+    });
+
+    expect(exception.scope).toEqual({
+      source: 'conformance',
+      category: 'boundary',
+      projectId: 'checkout-app',
+    });
+  });
+
+  it('builds stable scope keys across equivalent related project orderings', () => {
+    const first = buildGovernanceExceptionScopeKey({
+      source: 'conformance',
+      ruleId: 'enforce-module-boundaries',
+      relatedProjectIds: ['b', 'a', 'b'],
+    });
+    const second = buildGovernanceExceptionScopeKey({
+      source: 'conformance',
+      ruleId: 'enforce-module-boundaries',
+      relatedProjectIds: ['a', 'b'],
+    });
+
+    expect(first).toBe(second);
+    expect(first).toBe('conformance|enforce-module-boundaries|||a,b');
+  });
+
+  it('exposes policy and conformance scope type guards', () => {
+    const policy = normalizeGovernanceException({
+      id: 'policy-scope',
+      source: 'policy',
+      scope: {
+        source: 'policy',
+        ruleId: 'layer-boundary',
+        projectId: 'feature-lib',
+        targetProjectId: 'util-lib',
+      },
+      reason: 'Temporary layering gap.',
+      owner: '@org/architecture',
+      review: {
+        reviewBy: '2026-05-01',
+      },
+    }).scope;
+    const conformance = normalizeGovernanceException({
+      id: 'conformance-scope',
+      source: 'conformance',
+      scope: {
+        source: 'conformance',
+        ruleId: 'conformance-rule',
+      },
+      reason: 'Tooling false positive.',
+      owner: '@org/architecture',
+      review: {
+        expiresAt: '2026-06-01',
+      },
+    }).scope;
+
+    expect(isPolicyExceptionScope(policy)).toBe(true);
+    expect(isConformanceExceptionScope(policy)).toBe(false);
+    expect(isPolicyExceptionScope(conformance)).toBe(false);
+    expect(isConformanceExceptionScope(conformance)).toBe(true);
+  });
+
+  it('rejects empty required strings', () => {
+    expect(() =>
+      normalizeGovernanceException({
+        id: '  ',
+        source: 'policy',
+        scope: {
+          source: 'policy',
+          ruleId: 'domain-boundary',
+          projectId: 'billing-feature',
+        },
+        reason: 'Valid reason',
+        owner: '@org/architecture',
+        review: {
+          reviewBy: '2026-05-01',
+        },
+      })
+    ).toThrow('Exception id is required.');
+
+    expect(() =>
+      normalizeGovernanceException({
+        id: 'missing-reason',
+        source: 'policy',
+        scope: {
+          source: 'policy',
+          ruleId: 'domain-boundary',
+          projectId: 'billing-feature',
+        },
+        reason: '   ',
+        owner: '@org/architecture',
+        review: {
+          reviewBy: '2026-05-01',
+        },
+      })
+    ).toThrow('Exception reason is required.');
+
+    expect(() =>
+      normalizeGovernanceException({
+        id: 'missing-owner',
+        source: 'policy',
+        scope: {
+          source: 'policy',
+          ruleId: 'domain-boundary',
+          projectId: 'billing-feature',
+        },
+        reason: 'Valid reason',
+        owner: '   ',
+        review: {
+          reviewBy: '2026-05-01',
+        },
+      })
+    ).toThrow('Exception owner is required.');
+  });
+
+  it('rejects reviews without reviewBy or expiresAt', () => {
+    expect(() =>
+      normalizeGovernanceException({
+        id: 'missing-review-window',
+        source: 'policy',
+        scope: {
+          source: 'policy',
+          ruleId: 'domain-boundary',
+          projectId: 'billing-feature',
+        },
+        reason: 'Valid reason',
+        owner: '@org/architecture',
+        review: {
+          createdAt: '2026-04-17',
+        },
+      })
+    ).toThrow(
+      'Governance exception review must define reviewBy or expiresAt.'
+    );
+  });
+
+  it('rejects empty conformance scopes', () => {
+    expect(() =>
+      normalizeGovernanceException({
+        id: 'invalid-conformance-scope',
+        source: 'conformance',
+        scope: {
+          source: 'conformance',
+        },
+        reason: 'Valid reason',
+        owner: '@org/architecture',
+        review: {
+          expiresAt: '2026-06-01',
+        },
+      })
+    ).toThrow(
+      'Conformance exception scope must define ruleId, category, projectId, or relatedProjectIds.'
+    );
+  });
+
+  it('rejects mismatched top-level and scope sources', () => {
+    expect(() =>
+      normalizeGovernanceException({
+        id: 'source-mismatch',
+        source: 'policy',
+        scope: {
+          source: 'conformance',
+          ruleId: 'rule',
+        },
+        reason: 'Valid reason',
+        owner: '@org/architecture',
+        review: {
+          reviewBy: '2026-05-01',
+        },
+      })
+    ).toThrow(
+      'Exception "source-mismatch" has source "policy" but scope source "conformance".'
+    );
+  });
+});

--- a/packages/governance/src/core/exceptions.ts
+++ b/packages/governance/src/core/exceptions.ts
@@ -1,0 +1,201 @@
+import type { Category } from '../conformance-adapter/conformance-adapter.js';
+
+export type GovernanceExceptionSource = 'policy' | 'conformance';
+
+export interface GovernanceExceptionReview {
+  createdAt?: string;
+  reviewBy?: string;
+  expiresAt?: string;
+}
+
+export interface GovernancePolicyExceptionScope {
+  source: 'policy';
+  ruleId: string;
+  projectId: string;
+  targetProjectId?: string;
+}
+
+export interface GovernanceConformanceExceptionScope {
+  source: 'conformance';
+  ruleId?: string;
+  category?: Category;
+  projectId?: string;
+  relatedProjectIds?: string[];
+}
+
+export type GovernanceExceptionScope =
+  | GovernancePolicyExceptionScope
+  | GovernanceConformanceExceptionScope;
+
+export interface GovernanceException {
+  id: string;
+  source: GovernanceExceptionSource;
+  scope: GovernanceExceptionScope;
+  reason: string;
+  owner: string;
+  review: GovernanceExceptionReview;
+}
+
+export function normalizeGovernanceException(
+  exception: GovernanceException
+): GovernanceException {
+  const id = normalizeRequiredString(exception.id, 'Exception id');
+  const source = normalizeExceptionSource(exception.source);
+  const reason = normalizeRequiredString(exception.reason, 'Exception reason');
+  const owner = normalizeRequiredString(exception.owner, 'Exception owner');
+  const review = normalizeGovernanceExceptionReview(exception.review);
+  const scope = normalizeGovernanceExceptionScope(exception.scope);
+
+  if (scope.source !== source) {
+    throw new Error(
+      `Exception "${id}" has source "${source}" but scope source "${scope.source}".`
+    );
+  }
+
+  return {
+    id,
+    source,
+    scope,
+    reason,
+    owner,
+    review,
+  };
+}
+
+export function buildGovernanceExceptionScopeKey(
+  scope: GovernanceExceptionScope
+): string {
+  const normalizedScope = normalizeGovernanceExceptionScope(scope);
+
+  if (isPolicyExceptionScope(normalizedScope)) {
+    return [
+      normalizedScope.source,
+      normalizedScope.ruleId,
+      normalizedScope.projectId,
+      normalizedScope.targetProjectId ?? '',
+    ].join('|');
+  }
+
+  return [
+    normalizedScope.source,
+    normalizedScope.ruleId ?? '',
+    normalizedScope.category ?? '',
+    normalizedScope.projectId ?? '',
+    (normalizedScope.relatedProjectIds ?? []).join(','),
+  ].join('|');
+}
+
+export function isPolicyExceptionScope(
+  scope: GovernanceExceptionScope
+): scope is GovernancePolicyExceptionScope {
+  return scope.source === 'policy';
+}
+
+export function isConformanceExceptionScope(
+  scope: GovernanceExceptionScope
+): scope is GovernanceConformanceExceptionScope {
+  return scope.source === 'conformance';
+}
+
+function normalizeGovernanceExceptionReview(
+  review: GovernanceExceptionReview
+): GovernanceExceptionReview {
+  const createdAt = normalizeOptionalString(review.createdAt);
+  const reviewBy = normalizeOptionalString(review.reviewBy);
+  const expiresAt = normalizeOptionalString(review.expiresAt);
+
+  if (!reviewBy && !expiresAt) {
+    throw new Error(
+      'Governance exception review must define reviewBy or expiresAt.'
+    );
+  }
+
+  return {
+    ...(createdAt ? { createdAt } : {}),
+    ...(reviewBy ? { reviewBy } : {}),
+    ...(expiresAt ? { expiresAt } : {}),
+  };
+}
+
+function normalizeGovernanceExceptionScope(
+  scope: GovernanceExceptionScope
+): GovernanceExceptionScope {
+  if (scope.source === 'policy') {
+    return {
+      source: 'policy',
+      ruleId: normalizeRequiredString(scope.ruleId, 'Policy exception ruleId'),
+      projectId: normalizeRequiredString(
+        scope.projectId,
+        'Policy exception projectId'
+      ),
+      ...(normalizeOptionalString(scope.targetProjectId)
+        ? { targetProjectId: normalizeOptionalString(scope.targetProjectId) }
+        : {}),
+    };
+  }
+
+  const ruleId = normalizeOptionalString(scope.ruleId);
+  const category = normalizeOptionalCategory(scope.category);
+  const projectId = normalizeOptionalString(scope.projectId);
+  const relatedProjectIds = normalizeRelatedProjectIds(scope.relatedProjectIds);
+
+  if (!ruleId && !category && !projectId && relatedProjectIds.length === 0) {
+    throw new Error(
+      'Conformance exception scope must define ruleId, category, projectId, or relatedProjectIds.'
+    );
+  }
+
+  return {
+    source: 'conformance',
+    ...(ruleId ? { ruleId } : {}),
+    ...(category ? { category } : {}),
+    ...(projectId ? { projectId } : {}),
+    ...(relatedProjectIds.length > 0 ? { relatedProjectIds } : {}),
+  };
+}
+
+function normalizeExceptionSource(
+  source: GovernanceExceptionSource
+): GovernanceExceptionSource {
+  if (source === 'policy' || source === 'conformance') {
+    return source;
+  }
+
+  throw new Error(`Unsupported governance exception source "${source}".`);
+}
+
+function normalizeRequiredString(value: string, label: string): string {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized) {
+    throw new Error(`${label} is required.`);
+  }
+
+  return normalized;
+}
+
+function normalizeOptionalString(value: string | undefined): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeRelatedProjectIds(
+  relatedProjectIds: string[] | undefined
+): string[] {
+  if (!Array.isArray(relatedProjectIds)) {
+    return [];
+  }
+
+  return [...new Set(relatedProjectIds.map(normalizeOptionalString).filter(
+    (value): value is string => !!value
+  ))].sort((a, b) => a.localeCompare(b));
+}
+
+function normalizeOptionalCategory(
+  category: Category | undefined
+): Category | undefined {
+  return normalizeOptionalString(category) as Category | undefined;
+}

--- a/packages/governance/src/core/index.ts
+++ b/packages/governance/src/core/index.ts
@@ -1,2 +1,3 @@
 export * from './models.js';
+export * from './exceptions.js';
 export * from './profile.js';

--- a/packages/governance/src/index.ts
+++ b/packages/governance/src/index.ts
@@ -31,3 +31,4 @@ export * from './conformance-adapter/conformance-adapter.js';
 export * from './signal-engine/index.js';
 export * from './metric-engine/calculate-metrics.js';
 export * from './extensions/contracts.js';
+export * from './core/exceptions.js';


### PR DESCRIPTION
Introduce the raw governance graph document model and internal builder for graph-ready nodes, edges, findings, summary, and filter facets.

This also extracts an internal assessment-artifacts seam so raw governance signals remain available for graph generation while keeping existing runGovernance output and executor behavior unchanged.

Closes #90 Refs #89