### PR TITLE
feat(nx-governance): load declared governance exceptions from profiles

### DIFF
--- a/packages/governance/src/core/profile.ts
+++ b/packages/governance/src/core/profile.ts
@@ -1,3 +1,4 @@
+import { GovernanceException } from './exceptions.js';
 import { HealthStatusThresholds, Measurement } from './models.js';
 
 export const DEFAULT_HEALTH_STATUS_THRESHOLDS: HealthStatusThresholds = {
@@ -30,6 +31,7 @@ export interface ProfileOverrides {
     statusThresholds?: Partial<HealthStatusThresholds>;
   };
   metrics?: Partial<Record<string, number>>;
+  exceptions?: GovernanceException[];
   projectOverrides: Record<
     string,
     {

--- a/packages/governance/src/presets/angular-cleanup/profile.spec.ts
+++ b/packages/governance/src/presets/angular-cleanup/profile.spec.ts
@@ -1,0 +1,308 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { loadProfileOverrides } from './profile.js';
+
+describe('loadProfileOverrides', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns defaults with empty exceptions when the profile file is missing', async () => {
+    const workspaceRoot = mkTempWorkspaceRoot();
+
+    try {
+      const result = await loadProfileOverrides(
+        workspaceRoot,
+        'missing-profile'
+      );
+
+      expect(result.exceptions).toEqual([]);
+      expect(result.projectOverrides).toEqual({});
+    } finally {
+      cleanupTempWorkspaceRoot(workspaceRoot);
+    }
+  });
+
+  it('keeps existing behavior when no exceptions are declared', async () => {
+    const workspaceRoot = mkTempWorkspaceRoot();
+
+    try {
+      writeProfile(workspaceRoot, {
+        boundaryPolicySource: 'profile',
+        layers: ['app', 'feature', 'util'],
+        allowedDomainDependencies: {
+          '*': ['shared'],
+        },
+        ownership: {
+          required: false,
+          metadataField: 'ownership',
+        },
+        metrics: {
+          architecturalEntropyWeight: 0.4,
+        },
+        projectOverrides: {
+          'billing-app': {
+            documentation: true,
+          },
+        },
+      });
+
+      const result = await loadProfileOverrides(workspaceRoot, 'angular-cleanup');
+
+      expect(result.exceptions).toEqual([]);
+      expect(result.layers).toEqual(['app', 'feature', 'util']);
+      expect(result.ownership).toEqual({
+        required: false,
+        metadataField: 'ownership',
+      });
+      expect(result.metrics?.['architectural-entropy']).toBe(0.4);
+      expect(result.projectOverrides).toEqual({
+        'billing-app': {
+          documentation: true,
+        },
+      });
+    } finally {
+      cleanupTempWorkspaceRoot(workspaceRoot);
+    }
+  });
+
+  it('loads and normalizes policy and conformance exceptions', async () => {
+    const workspaceRoot = mkTempWorkspaceRoot();
+
+    try {
+      writeProfile(workspaceRoot, {
+        exceptions: [
+          {
+            id: ' z-conformance ',
+            source: 'conformance',
+            scope: {
+              source: 'conformance',
+              ruleId: ' enforce-module-boundaries ',
+              relatedProjectIds: ['payments-lib', 'checkout-app', 'payments-lib'],
+            },
+            reason: ' Known migration overlap. ',
+            owner: ' @org/architecture ',
+            review: {
+              reviewBy: ' 2026-06-01 ',
+            },
+          },
+          {
+            id: ' a-policy ',
+            source: 'policy',
+            scope: {
+              source: 'policy',
+              ruleId: ' domain-boundary ',
+              projectId: ' billing-feature ',
+              targetProjectId: ' shared-util ',
+            },
+            reason: ' Transitional boundary. ',
+            owner: ' @org/architecture ',
+            review: {
+              expiresAt: ' 2026-08-01 ',
+            },
+          },
+        ],
+      });
+
+      const result = await loadProfileOverrides(workspaceRoot, 'angular-cleanup');
+
+      expect(result.exceptions).toEqual([
+        {
+          id: 'a-policy',
+          source: 'policy',
+          scope: {
+            source: 'policy',
+            ruleId: 'domain-boundary',
+            projectId: 'billing-feature',
+            targetProjectId: 'shared-util',
+          },
+          reason: 'Transitional boundary.',
+          owner: '@org/architecture',
+          review: {
+            expiresAt: '2026-08-01',
+          },
+        },
+        {
+          id: 'z-conformance',
+          source: 'conformance',
+          scope: {
+            source: 'conformance',
+            ruleId: 'enforce-module-boundaries',
+            relatedProjectIds: ['checkout-app', 'payments-lib'],
+          },
+          reason: 'Known migration overlap.',
+          owner: '@org/architecture',
+          review: {
+            reviewBy: '2026-06-01',
+          },
+        },
+      ]);
+    } finally {
+      cleanupTempWorkspaceRoot(workspaceRoot);
+    }
+  });
+
+  it('rejects non-array exceptions', async () => {
+    const workspaceRoot = mkTempWorkspaceRoot();
+
+    try {
+      writeProfile(workspaceRoot, {
+        exceptions: {
+          id: 'invalid',
+        },
+      });
+
+      await expect(
+        loadProfileOverrides(workspaceRoot, 'angular-cleanup')
+      ).rejects.toThrow(
+        `Governance profile at ${path.join(
+          workspaceRoot,
+          'tools/governance/profiles/angular-cleanup.json'
+        )} has invalid exceptions: expected an array.`
+      );
+    } finally {
+      cleanupTempWorkspaceRoot(workspaceRoot);
+    }
+  });
+
+  it('rejects invalid exception entries with file-aware context', async () => {
+    const workspaceRoot = mkTempWorkspaceRoot();
+
+    try {
+      writeProfile(workspaceRoot, {
+        exceptions: [
+          {
+            id: 'bad-review',
+            source: 'policy',
+            scope: {
+              source: 'policy',
+              ruleId: 'domain-boundary',
+              projectId: 'billing-feature',
+            },
+            reason: 'Missing review window.',
+            owner: '@org/architecture',
+            review: {},
+          },
+        ],
+      });
+
+      await expect(
+        loadProfileOverrides(workspaceRoot, 'angular-cleanup')
+      ).rejects.toMatchObject({
+        message: expect.stringContaining(
+          `Governance profile at ${path.join(
+            workspaceRoot,
+            'tools/governance/profiles/angular-cleanup.json'
+          )} has invalid exception "bad-review" at index 0: Governance exception review must define reviewBy or expiresAt.`
+        ),
+      });
+    } finally {
+      cleanupTempWorkspaceRoot(workspaceRoot);
+    }
+  });
+
+  it('rejects duplicate exception ids', async () => {
+    const workspaceRoot = mkTempWorkspaceRoot();
+
+    try {
+      writeProfile(workspaceRoot, {
+        exceptions: [
+          {
+            id: 'duplicate-id',
+            source: 'policy',
+            scope: {
+              source: 'policy',
+              ruleId: 'domain-boundary',
+              projectId: 'billing-feature',
+            },
+            reason: 'First exception.',
+            owner: '@org/architecture',
+            review: {
+              reviewBy: '2026-06-01',
+            },
+          },
+          {
+            id: 'duplicate-id',
+            source: 'conformance',
+            scope: {
+              source: 'conformance',
+              ruleId: 'enforce-module-boundaries',
+            },
+            reason: 'Second exception.',
+            owner: '@org/architecture',
+            review: {
+              expiresAt: '2026-08-01',
+            },
+          },
+        ],
+      });
+
+      await expect(
+        loadProfileOverrides(workspaceRoot, 'angular-cleanup')
+      ).rejects.toThrow(
+        `Governance profile at ${path.join(
+          workspaceRoot,
+          'tools/governance/profiles/angular-cleanup.json'
+        )} has duplicate exception id "duplicate-id".`
+      );
+    } finally {
+      cleanupTempWorkspaceRoot(workspaceRoot);
+    }
+  });
+
+  it('rejects mismatched top-level and scope sources through the loader', async () => {
+    const workspaceRoot = mkTempWorkspaceRoot();
+
+    try {
+      writeProfile(workspaceRoot, {
+        exceptions: [
+          {
+            id: 'source-mismatch',
+            source: 'policy',
+            scope: {
+              source: 'conformance',
+              ruleId: 'enforce-module-boundaries',
+            },
+            reason: 'Mismatched source.',
+            owner: '@org/architecture',
+            review: {
+              reviewBy: '2026-06-01',
+            },
+          },
+        ],
+      });
+
+      await expect(
+        loadProfileOverrides(workspaceRoot, 'angular-cleanup')
+      ).rejects.toMatchObject({
+        message: expect.stringContaining(
+          'Exception "source-mismatch" has source "policy" but scope source "conformance".'
+        ),
+      });
+    } finally {
+      cleanupTempWorkspaceRoot(workspaceRoot);
+    }
+  });
+});
+
+function mkTempWorkspaceRoot(): string {
+  return mkdtempSync(path.join(tmpdir(), 'nx-governance-profile-'));
+}
+
+function cleanupTempWorkspaceRoot(workspaceRoot: string): void {
+  rmSync(workspaceRoot, { recursive: true, force: true });
+}
+
+function writeProfile(
+  workspaceRoot: string,
+  content: Record<string, unknown>
+): void {
+  const profilesDir = path.join(workspaceRoot, 'tools/governance/profiles');
+  mkdirSync(profilesDir, { recursive: true });
+  writeFileSync(
+    path.join(profilesDir, 'angular-cleanup.json'),
+    `${JSON.stringify(content, null, 2)}\n`
+  );
+}

--- a/packages/governance/src/presets/angular-cleanup/profile.ts
+++ b/packages/governance/src/presets/angular-cleanup/profile.ts
@@ -4,10 +4,12 @@ import { pathToFileURL } from 'node:url';
 
 import {
   DEFAULT_HEALTH_STATUS_THRESHOLDS,
+  GovernanceException,
   GovernanceProfile,
   HealthStatusThresholds,
   Measurement,
   ProfileOverrides,
+  normalizeGovernanceException,
 } from '../../core/index.js';
 
 const LEGACY_PROFILE_METRIC_KEY_MAP = {
@@ -46,6 +48,7 @@ export const angularCleanupProfile: GovernanceProfile = {
 
 export interface ResolvedProfileOverrides extends ProfileOverrides {
   boundaryPolicySource: GovernanceProfile['boundaryPolicySource'];
+  exceptions: GovernanceException[];
   runtimeWarnings: string[];
 }
 
@@ -67,6 +70,7 @@ export async function loadProfileOverrides(
       ownership: angularCleanupProfile.ownership,
       health: angularCleanupProfile.health,
       metrics: angularCleanupProfile.metrics,
+      exceptions: [],
       projectOverrides: {},
       runtimeWarnings: [],
     };
@@ -79,6 +83,7 @@ export async function loadProfileOverrides(
     ownership?: ProfileOverrides['ownership'];
     health?: ProfileOverrides['health'];
     metrics?: Record<string, number>;
+    exceptions?: unknown;
     projectOverrides?: ProfileOverrides['projectOverrides'];
   };
 
@@ -96,6 +101,8 @@ export async function loadProfileOverrides(
           'Boundary policy source is ESLint constraints (tools/governance/eslint/dependency-constraints.mjs). Profile allowedDomainDependencies is treated as fallback.',
         ]
       : [];
+
+  const exceptions = normalizeProfileExceptions(raw.exceptions, filePath);
 
   return {
     boundaryPolicySource,
@@ -121,6 +128,7 @@ export async function loadProfileOverrides(
       ...angularCleanupProfile.metrics,
       ...normalizeMetricWeights(raw.metrics),
     },
+    exceptions,
     projectOverrides: raw.projectOverrides ?? {},
     runtimeWarnings,
   };
@@ -249,4 +257,65 @@ function normalizeThresholdValue(value: unknown, fallback: number): number {
   }
 
   return Math.max(0, Math.min(100, value));
+}
+
+function normalizeProfileExceptions(
+  raw: unknown,
+  filePath: string
+): GovernanceException[] {
+  if (raw === undefined) {
+    return [];
+  }
+
+  if (!Array.isArray(raw)) {
+    throw new Error(
+      `Governance profile at ${filePath} has invalid exceptions: expected an array.`
+    );
+  }
+
+  const normalized = raw.map((entry, index) =>
+    normalizeProfileExceptionEntry(entry, index, filePath)
+  );
+  const ids = new Set<string>();
+
+  for (const exception of normalized) {
+    if (ids.has(exception.id)) {
+      throw new Error(
+        `Governance profile at ${filePath} has duplicate exception id "${exception.id}".`
+      );
+    }
+
+    ids.add(exception.id);
+  }
+
+  return normalized.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function normalizeProfileExceptionEntry(
+  entry: unknown,
+  index: number,
+  filePath: string
+): GovernanceException {
+  if (!entry || typeof entry !== 'object') {
+    throw new Error(
+      `Governance profile at ${filePath} has invalid exception at index ${index}: expected an object.`
+    );
+  }
+
+  const candidate = entry as Partial<GovernanceException>;
+  const candidateId =
+    typeof candidate.id === 'string' && candidate.id.trim().length > 0
+      ? candidate.id.trim()
+      : `#${index}`;
+
+  try {
+    return normalizeGovernanceException(candidate as GovernanceException);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Unknown exception error.';
+
+    throw new Error(
+      `Governance profile at ${filePath} has invalid exception "${candidateId}" at index ${index}: ${message}`
+    );
+  }
 }


### PR DESCRIPTION
Extend the governance profile override schema to support explicit `exceptions` declarations and normalize them during profile loading.

This adds deterministic exception loading, validation, duplicate id checks, and file-aware error reporting while keeping governance evaluation, reporting, and generated profile defaults unchanged.

Closes #98 Refs #96 Refs #97