### PR TITLE
feat(nx-governance): apply declared exceptions during evaluation

### DIFF
--- a/packages/governance/src/plugin/apply-governance-exceptions.spec.ts
+++ b/packages/governance/src/plugin/apply-governance-exceptions.spec.ts
@@ -1,0 +1,262 @@
+import type { GovernanceException, Violation } from '../core/index.js';
+import type { ConformanceFinding, ConformanceSnapshot } from '../conformance-adapter/conformance-adapter.js';
+import {
+  buildConformanceSignals,
+  buildPolicySignals,
+} from '../signal-engine/index.js';
+import { applyGovernanceExceptions } from './apply-governance-exceptions.js';
+
+describe('applyGovernanceExceptions', () => {
+  it('suppresses matching policy violations, including project-only ownership exceptions', () => {
+    const violations: Violation[] = [
+      {
+        id: 'billing-shared-domain',
+        ruleId: 'domain-boundary',
+        project: 'billing-feature',
+        severity: 'error',
+        category: 'boundary',
+        message: 'billing-feature crosses into shared-util.',
+        details: {
+          targetProject: 'shared-util',
+        },
+      },
+      {
+        id: 'billing-ownership',
+        ruleId: 'ownership-presence',
+        project: 'billing-feature',
+        severity: 'warning',
+        category: 'ownership',
+        message: 'billing-feature has no owner.',
+      },
+    ];
+    const exceptions: GovernanceException[] = [
+      {
+        id: 'billing-domain-transition',
+        source: 'policy',
+        scope: {
+          source: 'policy',
+          ruleId: 'domain-boundary',
+          projectId: 'billing-feature',
+          targetProjectId: 'shared-util',
+        },
+        reason: 'Temporary transition.',
+        owner: '@org/architecture',
+        review: {
+          reviewBy: '2026-06-01',
+        },
+      },
+      {
+        id: 'billing-ownership-gap',
+        source: 'policy',
+        scope: {
+          source: 'policy',
+          ruleId: 'ownership-presence',
+          projectId: 'billing-feature',
+        },
+        reason: 'Ownership migration in progress.',
+        owner: '@org/architecture',
+        review: {
+          expiresAt: '2026-07-01',
+        },
+      },
+    ];
+
+    const result = applyGovernanceExceptions({
+      exceptions,
+      policyViolations: violations,
+      conformanceFindings: [],
+    });
+
+    expect(result.activePolicyViolations).toEqual([]);
+    expect(result.suppressedPolicyViolations).toEqual([
+      expect.objectContaining({
+        finding: violations[0],
+        matchedExceptionId: 'billing-domain-transition',
+        outcome: 'suppressed',
+      }),
+      expect.objectContaining({
+        finding: violations[1],
+        matchedExceptionId: 'billing-ownership-gap',
+        outcome: 'suppressed',
+      }),
+    ]);
+    expect(buildPolicySignals(result.activePolicyViolations)).toEqual([]);
+  });
+
+  it('prefers the most specific policy exception match', () => {
+    const violation: Violation = {
+      id: 'billing-shared-domain',
+      ruleId: 'domain-boundary',
+      project: 'billing-feature',
+      severity: 'error',
+      category: 'boundary',
+      message: 'billing-feature crosses into shared-util.',
+      details: {
+        targetProject: 'shared-util',
+      },
+    };
+    const result = applyGovernanceExceptions({
+      exceptions: [
+        {
+          id: 'billing-any-domain',
+          source: 'policy',
+          scope: {
+            source: 'policy',
+            ruleId: 'domain-boundary',
+            projectId: 'billing-feature',
+          },
+          reason: 'Broader exception.',
+          owner: '@org/architecture',
+          review: {
+            reviewBy: '2026-06-01',
+          },
+        },
+        {
+          id: 'billing-shared-domain',
+          source: 'policy',
+          scope: {
+            source: 'policy',
+            ruleId: 'domain-boundary',
+            projectId: 'billing-feature',
+            targetProjectId: 'shared-util',
+          },
+          reason: 'More specific exception.',
+          owner: '@org/architecture',
+          review: {
+            reviewBy: '2026-06-01',
+          },
+        },
+      ],
+      policyViolations: [violation],
+      conformanceFindings: [],
+    });
+
+    expect(result.suppressedPolicyViolations).toEqual([
+      expect.objectContaining({
+        matchedExceptionId: 'billing-shared-domain',
+      }),
+    ]);
+  });
+
+  it('suppresses conformance findings using exact scope matching and related-project equality', () => {
+    const finding: ConformanceFinding = {
+      id: 'conformance-1',
+      ruleId: '@nx/conformance/enforce-project-boundaries',
+      category: 'boundary',
+      severity: 'error',
+      projectId: 'billing-feature',
+      relatedProjectIds: ['shared-util', 'billing-feature'],
+      message: 'Conformance boundary violation.',
+    };
+    const result = applyGovernanceExceptions({
+      exceptions: [
+        {
+          id: 'conformance-boundary',
+          source: 'conformance',
+          scope: {
+            source: 'conformance',
+            ruleId: '@nx/conformance/enforce-project-boundaries',
+            relatedProjectIds: ['billing-feature', 'shared-util'],
+          },
+          reason: 'Known migration overlap.',
+          owner: '@org/architecture',
+          review: {
+            expiresAt: '2026-07-01',
+          },
+        },
+      ],
+      policyViolations: [],
+      conformanceFindings: [finding],
+    });
+
+    expect(result.activeConformanceFindings).toEqual([]);
+    expect(result.suppressedConformanceFindings).toEqual([
+      expect.objectContaining({
+        finding,
+        matchedExceptionId: 'conformance-boundary',
+        outcome: 'suppressed',
+      }),
+    ]);
+    expect(
+      buildConformanceSignals(makeConformanceSnapshot(result.activeConformanceFindings))
+    ).toEqual([]);
+  });
+
+  it('prefers the most specific conformance exception and leaves unmatched findings active', () => {
+    const findings: ConformanceFinding[] = [
+      {
+        id: 'specific-match',
+        ruleId: '@nx/conformance/enforce-project-boundaries',
+        category: 'boundary',
+        severity: 'error',
+        projectId: 'billing-feature',
+        relatedProjectIds: ['shared-util'],
+        message: 'Specific conformance boundary violation.',
+      },
+      {
+        id: 'active-finding',
+        ruleId: '@nx/conformance/ensure-owners',
+        category: 'ownership',
+        severity: 'warning',
+        projectId: 'billing-feature',
+        relatedProjectIds: [],
+        message: 'Ownership warning.',
+      },
+    ];
+
+    const result = applyGovernanceExceptions({
+      exceptions: [
+        {
+          id: 'broader-boundary',
+          source: 'conformance',
+          scope: {
+            source: 'conformance',
+            category: 'boundary',
+            projectId: 'billing-feature',
+          },
+          reason: 'Broader exception.',
+          owner: '@org/architecture',
+          review: {
+            reviewBy: '2026-06-01',
+          },
+        },
+        {
+          id: 'specific-boundary',
+          source: 'conformance',
+          scope: {
+            source: 'conformance',
+            ruleId: '@nx/conformance/enforce-project-boundaries',
+            category: 'boundary',
+            projectId: 'billing-feature',
+          },
+          reason: 'Specific exception.',
+          owner: '@org/architecture',
+          review: {
+            reviewBy: '2026-06-01',
+          },
+        },
+      ],
+      policyViolations: [],
+      conformanceFindings: findings,
+    });
+
+    expect(result.suppressedConformanceFindings).toEqual([
+      expect.objectContaining({
+        finding: findings[0],
+        matchedExceptionId: 'specific-boundary',
+      }),
+    ]);
+    expect(result.activeConformanceFindings).toEqual([findings[1]]);
+  });
+});
+
+function makeConformanceSnapshot(
+  findings: ConformanceSnapshot['findings']
+): ConformanceSnapshot {
+  return {
+    workspaceId: 'workspace',
+    findings,
+    extractedAt: '2026-04-17T00:00:00.000Z',
+    source: 'nx-conformance',
+  };
+}

--- a/packages/governance/src/plugin/apply-governance-exceptions.ts
+++ b/packages/governance/src/plugin/apply-governance-exceptions.ts
@@ -1,0 +1,283 @@
+import type {
+  GovernanceException,
+  GovernancePolicyExceptionScope,
+  GovernanceConformanceExceptionScope,
+  Violation,
+} from '../core/index.js';
+import {
+  buildGovernanceExceptionScopeKey,
+  isConformanceExceptionScope,
+  isPolicyExceptionScope,
+} from '../core/index.js';
+import type { ConformanceFinding } from '../conformance-adapter/conformance-adapter.js';
+
+export interface GovernanceExceptionMatch {
+  exceptionId: string;
+  scopeKey: string;
+  specificity: number;
+}
+
+export interface GovernanceAppliedFinding<T> {
+  finding: T;
+  outcome: 'active' | 'suppressed';
+  matchedExceptionId?: string;
+}
+
+export interface GovernanceSuppressedFinding<T> {
+  finding: T;
+  outcome: 'suppressed';
+  matchedExceptionId: string;
+}
+
+export interface GovernanceExceptionApplicationResult {
+  declaredExceptions: GovernanceException[];
+  policyViolations: GovernanceAppliedFinding<Violation>[];
+  conformanceFindings: GovernanceAppliedFinding<ConformanceFinding>[];
+  activePolicyViolations: Violation[];
+  suppressedPolicyViolations: GovernanceSuppressedFinding<Violation>[];
+  activeConformanceFindings: ConformanceFinding[];
+  suppressedConformanceFindings: GovernanceSuppressedFinding<ConformanceFinding>[];
+}
+
+export interface ApplyGovernanceExceptionsInput {
+  exceptions: GovernanceException[];
+  policyViolations: Violation[];
+  conformanceFindings: ConformanceFinding[];
+}
+
+export function applyGovernanceExceptions(
+  input: ApplyGovernanceExceptionsInput
+): GovernanceExceptionApplicationResult {
+  const policyViolations = input.policyViolations.map((violation) =>
+    applyPolicyException(violation, input.exceptions)
+  );
+  const conformanceFindings = input.conformanceFindings.map((finding) =>
+    applyConformanceException(finding, input.exceptions)
+  );
+
+  return {
+    declaredExceptions: [...input.exceptions],
+    policyViolations,
+    conformanceFindings,
+    activePolicyViolations: policyViolations
+      .filter((entry) => entry.outcome === 'active')
+      .map((entry) => entry.finding),
+    suppressedPolicyViolations: policyViolations.filter(isSuppressedFinding),
+    activeConformanceFindings: conformanceFindings
+      .filter((entry) => entry.outcome === 'active')
+      .map((entry) => entry.finding),
+    suppressedConformanceFindings: conformanceFindings.filter(
+      isSuppressedFinding
+    ),
+  };
+}
+
+function applyPolicyException(
+  violation: Violation,
+  exceptions: GovernanceException[]
+): GovernanceAppliedFinding<Violation> {
+  const bestMatch = selectBestMatch(
+    exceptions
+      .filter((exception) => exception.source === 'policy')
+      .flatMap((exception) => {
+        const match = matchPolicyException(exception.scope, violation);
+        return match
+          ? [
+              {
+                ...match,
+                exceptionId: exception.id,
+              },
+            ]
+          : [];
+      })
+  );
+
+  if (!bestMatch) {
+    return {
+      finding: violation,
+      outcome: 'active',
+    };
+  }
+
+  return {
+    finding: violation,
+    outcome: 'suppressed',
+    matchedExceptionId: bestMatch.exceptionId,
+  };
+}
+
+function applyConformanceException(
+  finding: ConformanceFinding,
+  exceptions: GovernanceException[]
+): GovernanceAppliedFinding<ConformanceFinding> {
+  const bestMatch = selectBestMatch(
+    exceptions
+      .filter((exception) => exception.source === 'conformance')
+      .flatMap((exception) => {
+        const match = matchConformanceException(exception.scope, finding);
+        return match
+          ? [
+              {
+                ...match,
+                exceptionId: exception.id,
+              },
+            ]
+          : [];
+      })
+  );
+
+  if (!bestMatch) {
+    return {
+      finding,
+      outcome: 'active',
+    };
+  }
+
+  return {
+    finding,
+    outcome: 'suppressed',
+    matchedExceptionId: bestMatch.exceptionId,
+  };
+}
+
+function matchPolicyException(
+  scope: GovernanceException['scope'],
+  violation: Violation
+): Omit<GovernanceExceptionMatch, 'exceptionId'> | null {
+  if (!isPolicyExceptionScope(scope)) {
+    return null;
+  }
+
+  const targetProjectId = normalizeText(violation.details?.targetProject);
+
+  if (scope.ruleId !== violation.ruleId || scope.projectId !== violation.project) {
+    return null;
+  }
+
+  if (scope.targetProjectId && scope.targetProjectId !== targetProjectId) {
+    return null;
+  }
+
+  return {
+    scopeKey: buildGovernanceExceptionScopeKey(scope),
+    specificity: getPolicySpecificity(scope),
+  };
+}
+
+function matchConformanceException(
+  scope: GovernanceException['scope'],
+  finding: ConformanceFinding
+): Omit<GovernanceExceptionMatch, 'exceptionId'> | null {
+  if (!isConformanceExceptionScope(scope)) {
+    return null;
+  }
+
+  if (scope.ruleId && scope.ruleId !== finding.ruleId) {
+    return null;
+  }
+
+  if (scope.category && scope.category !== finding.category) {
+    return null;
+  }
+
+  if (scope.projectId && scope.projectId !== finding.projectId) {
+    return null;
+  }
+
+  if (
+    scope.relatedProjectIds &&
+    !areEqualRelatedProjectIds(scope.relatedProjectIds, finding.relatedProjectIds)
+  ) {
+    return null;
+  }
+
+  return {
+    scopeKey: buildGovernanceExceptionScopeKey(scope),
+    specificity: getConformanceSpecificity(scope),
+  };
+}
+
+function selectBestMatch(
+  matches: GovernanceExceptionMatch[]
+): GovernanceExceptionMatch | null {
+  if (matches.length === 0) {
+    return null;
+  }
+
+  return [...matches].sort(compareExceptionMatches)[0] ?? null;
+}
+
+function compareExceptionMatches(
+  left: GovernanceExceptionMatch,
+  right: GovernanceExceptionMatch
+): number {
+  if (left.specificity !== right.specificity) {
+    return right.specificity - left.specificity;
+  }
+
+  const scopeComparison = left.scopeKey.localeCompare(right.scopeKey);
+  if (scopeComparison !== 0) {
+    return scopeComparison;
+  }
+
+  return left.exceptionId.localeCompare(right.exceptionId);
+}
+
+function getPolicySpecificity(scope: GovernancePolicyExceptionScope): number {
+  return scope.targetProjectId ? 2 : 1;
+}
+
+function getConformanceSpecificity(
+  scope: GovernanceConformanceExceptionScope
+): number {
+  return [
+    scope.ruleId,
+    scope.category,
+    scope.projectId,
+    scope.relatedProjectIds?.length ? 'relatedProjectIds' : undefined,
+  ].filter(Boolean).length;
+}
+
+function areEqualRelatedProjectIds(
+  left: string[],
+  right: string[]
+): boolean {
+  const normalizedLeft = normalizeRelatedProjectIds(left);
+  const normalizedRight = normalizeRelatedProjectIds(right);
+
+  if (normalizedLeft.length !== normalizedRight.length) {
+    return false;
+  }
+
+  return normalizedLeft.every((projectId, index) => {
+    return projectId === normalizedRight[index];
+  });
+}
+
+function normalizeRelatedProjectIds(projectIds: string[]): string[] {
+  return [...new Set(projectIds.map(normalizeText).filter(isDefined))].sort(
+    (left, right) => left.localeCompare(right)
+  );
+}
+
+function normalizeText(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function isDefined<T>(value: T | undefined): value is T {
+  return value !== undefined;
+}
+
+function isSuppressedFinding<T>(
+  finding: GovernanceAppliedFinding<T>
+): finding is GovernanceSuppressedFinding<T> {
+  return (
+    finding.outcome === 'suppressed' &&
+    typeof finding.matchedExceptionId === 'string'
+  );
+}

--- a/packages/governance/src/plugin/build-assessment-artifacts.ts
+++ b/packages/governance/src/plugin/build-assessment-artifacts.ts
@@ -1,0 +1,9 @@
+import type { GovernanceAssessment } from '../core/index.js';
+import type { GovernanceSignal } from '../signal-engine/index.js';
+import type { GovernanceExceptionApplicationResult } from './apply-governance-exceptions.js';
+
+export interface GovernanceAssessmentArtifacts {
+  assessment: GovernanceAssessment;
+  signals: GovernanceSignal[];
+  exceptionApplication: GovernanceExceptionApplicationResult;
+}

--- a/packages/governance/src/plugin/run-governance.spec.ts
+++ b/packages/governance/src/plugin/run-governance.spec.ts
@@ -3,9 +3,21 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
+jest.mock('../presets/angular-cleanup/profile.js', () => {
+  const actual = jest.requireActual(
+    '../presets/angular-cleanup/profile.js'
+  ) as typeof import('../presets/angular-cleanup/profile.js');
+
+  return {
+    ...actual,
+    loadProfileOverrides: jest.fn(actual.loadProfileOverrides),
+  };
+});
+
 import { logger, workspaceRoot } from '@nx/devkit';
 
 import { calculateHealthScore } from '../health-engine/calculate-health.js';
+import * as profileModule from '../presets/angular-cleanup/profile.js';
 import {
   angularCleanupProfile,
   loadProfileOverrides,
@@ -24,6 +36,11 @@ import {
   runGovernanceSnapshot,
 } from './run-governance.js';
 
+const actualProfileModule = jest.requireActual(
+  '../presets/angular-cleanup/profile.js'
+) as typeof import('../presets/angular-cleanup/profile.js');
+const mockedLoadProfileOverrides = jest.mocked(profileModule.loadProfileOverrides);
+
 describe('runGovernance', () => {
   function writeSnapshotFile(
     directory: string,
@@ -37,6 +54,9 @@ describe('runGovernance', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
+    mockedLoadProfileOverrides.mockImplementation(
+      actualProfileModule.loadProfileOverrides
+    );
   });
 
   it('keeps report measurement ids stable across report types after signal-based metric wiring', async () => {
@@ -235,6 +255,110 @@ describe('runGovernance', () => {
       );
       expect(withConformance.assessment.health.score).toBeLessThanOrEqual(
         baseline.assessment.health.score
+      );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('suppresses matching declared exceptions before conformance signals are built', async () => {
+    jest.spyOn(logger, 'info').mockImplementation(() => undefined);
+
+    const tempDir = mkdtempSync(
+      path.join(tmpdir(), 'nx-governance-conformance-')
+    );
+    const conformanceJson = path.join(tempDir, 'conformance.json');
+
+    writeFileSync(
+      conformanceJson,
+      JSON.stringify([
+        {
+          id: 'suppressed-finding',
+          ruleId: '@nx/conformance/enforce-project-boundaries',
+          severity: 'error',
+          message: 'Suppressed conformance boundary violation',
+          projectId: 'packages/governance',
+          relatedProjectIds: ['packages/governance', 'packages/governance-e2e'],
+        },
+        {
+          id: 'active-finding',
+          ruleId: '@nx/conformance/ensure-owners',
+          severity: 'warning',
+          message: 'Active conformance ownership warning',
+          projectId: 'packages/governance',
+        },
+      ])
+    );
+
+    const baseline = await runGovernance({
+      reportType: 'health',
+      conformanceJson,
+    });
+
+    const resolvedOverrides = await loadProfileOverrides(
+      workspaceRoot,
+      'angular-cleanup'
+    );
+    mockedLoadProfileOverrides.mockResolvedValueOnce({
+      ...resolvedOverrides,
+      exceptions: [
+        {
+          id: 'suppress-conformance-boundary',
+          source: 'conformance',
+          scope: {
+            source: 'conformance',
+            ruleId: '@nx/conformance/enforce-project-boundaries',
+            projectId: 'packages/governance',
+          },
+          reason: 'Known migration overlap.',
+          owner: '@org/architecture',
+          review: {
+            reviewBy: '2026-06-01',
+          },
+        },
+      ],
+    });
+
+    try {
+      const withException = await runGovernance({
+        reportType: 'health',
+        conformanceJson,
+      });
+
+      expect(
+        baseline.assessment.signalBreakdown.bySource.find(
+          (entry) => entry.source === 'conformance'
+        )
+      ).toEqual({ source: 'conformance', count: 2 });
+      expect(
+        withException.assessment.signalBreakdown.bySource.find(
+          (entry) => entry.source === 'conformance'
+        )
+      ).toEqual({ source: 'conformance', count: 1 });
+      expect(
+        withException.assessment.topIssues.filter(
+          (issue) =>
+            issue.source === 'conformance' &&
+            issue.type === 'conformance-violation'
+        )
+      ).toEqual([
+        expect.objectContaining({
+          severity: 'warning',
+          count: 1,
+          message: 'Active conformance ownership warning',
+        }),
+      ]);
+      expect(withException.assessment.health.score).toBeGreaterThanOrEqual(
+        baseline.assessment.health.score
+      );
+      expect(
+        Object.keys(withException.assessment).sort((left, right) =>
+          left.localeCompare(right)
+        )
+      ).toEqual(
+        Object.keys(baseline.assessment).sort((left, right) =>
+          left.localeCompare(right)
+        )
       );
     } finally {
       rmSync(tempDir, { recursive: true, force: true });

--- a/packages/governance/src/plugin/run-governance.ts
+++ b/packages/governance/src/plugin/run-governance.ts
@@ -79,6 +79,9 @@ import {
   evaluateGovernanceRulePacks,
   registerGovernanceExtensions,
 } from '../extensions/host.js';
+import { applyGovernanceExceptions } from './apply-governance-exceptions.js';
+import type { GovernanceAssessmentArtifacts } from './build-assessment-artifacts.js';
+import type { ConformanceSnapshot } from '../conformance-adapter/conformance-adapter.js';
 
 export interface GovernanceRunOptions {
   profile?: string;
@@ -261,7 +264,7 @@ const AI_PAYLOAD_LIMITS = {
 export async function runGovernance(
   options: GovernanceRunOptions = {}
 ): Promise<GovernanceRunResult> {
-  const assessment = await buildAssessment(options);
+  const { assessment } = await buildAssessmentArtifacts(options);
 
   const rendered =
     options.output === 'json'
@@ -287,7 +290,7 @@ export async function runGovernance(
 export async function runGovernanceSnapshot(
   options: GovernanceSnapshotRunOptions = {}
 ): Promise<GovernanceSnapshotRunResult> {
-  const assessment = await buildAssessment({
+  const { assessment } = await buildAssessmentArtifacts({
     ...options,
     reportType: 'health',
   });
@@ -1449,6 +1452,14 @@ export async function runGovernanceAiOnboarding(
 async function buildAssessment(
   options: GovernanceRunOptions
 ): Promise<GovernanceAssessment> {
+  const { assessment } = await buildAssessmentArtifacts(options);
+
+  return assessment;
+}
+
+async function buildAssessmentArtifacts(
+  options: GovernanceRunOptions
+): Promise<GovernanceAssessmentArtifacts> {
   const profileName = options.profile ?? 'angular-cleanup';
 
   const overrides = await loadProfileOverrides(workspaceRoot, profileName);
@@ -1495,6 +1506,15 @@ async function buildAssessment(
     },
   });
   const coreViolations = evaluatePolicies(enrichedInventory, effectiveProfile);
+  const resolvedConformanceInput = resolveConformanceInput(
+    options.conformanceJson
+  );
+  const conformanceSnapshot = loadConformanceSnapshot(resolvedConformanceInput);
+  const exceptionApplication = applyGovernanceExceptions({
+    exceptions: overrides.exceptions,
+    policyViolations: coreViolations,
+    conformanceFindings: conformanceSnapshot?.findings ?? [],
+  });
   const extensionViolations = await evaluateGovernanceRulePacks(
     extensionRegistry,
     {
@@ -1509,15 +1529,20 @@ async function buildAssessment(
       },
     }
   );
-  const allViolations = [...coreViolations, ...extensionViolations];
+  const allViolations = [
+    ...exceptionApplication.activePolicyViolations,
+    ...extensionViolations,
+  ];
   const graphSignals = buildGraphSignals(
     toWorkspaceGraphSnapshot(enrichedInventory)
   );
-  const policySignals = buildPolicySignals(allViolations);
-  const resolvedConformanceInput = resolveConformanceInput(
-    options.conformanceJson
+  const policySignals = buildPolicySignals(
+    exceptionApplication.activePolicyViolations
   );
-  const conformanceSignals = loadConformanceSignals(resolvedConformanceInput);
+  const conformanceSignals = buildConformanceSignalsForActiveFindings(
+    conformanceSnapshot,
+    exceptionApplication.activeConformanceFindings
+  );
   const coreSignals = mergeGovernanceSignals(
     graphSignals,
     conformanceSignals,
@@ -1574,23 +1599,27 @@ async function buildAssessment(
   );
 
   return {
-    workspace: enrichedInventory,
-    profile: profileName,
-    warnings: overrides.runtimeWarnings,
-    violations: filteredViolations,
-    measurements: filteredMeasurements,
-    signalBreakdown: buildSignalBreakdown(filteredSignals),
-    metricBreakdown: buildMetricBreakdown(filteredMeasurements),
-    topIssues: buildTopIssues(filteredSignals),
-    health: calculateHealthScore(
-      allMeasurements,
-      effectiveProfile.metrics,
-      effectiveProfile.health.statusThresholds,
-      {
-        topIssues: allTopIssues,
-      }
-    ),
-    recommendations: buildRecommendations(allViolations, allMeasurements),
+    assessment: {
+      workspace: enrichedInventory,
+      profile: profileName,
+      warnings: overrides.runtimeWarnings,
+      violations: filteredViolations,
+      measurements: filteredMeasurements,
+      signalBreakdown: buildSignalBreakdown(filteredSignals),
+      metricBreakdown: buildMetricBreakdown(filteredMeasurements),
+      topIssues: buildTopIssues(filteredSignals),
+      health: calculateHealthScore(
+        allMeasurements,
+        effectiveProfile.metrics,
+        effectiveProfile.health.statusThresholds,
+        {
+          topIssues: allTopIssues,
+        }
+      ),
+      recommendations: buildRecommendations(allViolations, allMeasurements),
+    },
+    signals: allSignals,
+    exceptionApplication,
   };
 }
 
@@ -1679,17 +1708,15 @@ function normalizeMetricWeights(
   );
 }
 
-function loadConformanceSignals(
+function loadConformanceSnapshot(
   input: ReturnType<typeof resolveConformanceInput>
-) {
+): ConformanceSnapshot | undefined {
   if (!input.conformanceJson) {
-    return [];
+    return undefined;
   }
 
   try {
-    return buildConformanceSignals(
-      readConformanceSnapshot({ conformanceJson: input.conformanceJson })
-    );
+    return readConformanceSnapshot({ conformanceJson: input.conformanceJson });
   } catch (error) {
     if (input.source === 'nx-json') {
       throw new Error(
@@ -1701,6 +1728,20 @@ function loadConformanceSignals(
 
     throw error;
   }
+}
+
+function buildConformanceSignalsForActiveFindings(
+  snapshot: ConformanceSnapshot | undefined,
+  findings: ConformanceSnapshot['findings']
+) {
+  if (!snapshot) {
+    return [];
+  }
+
+  return buildConformanceSignals({
+    ...snapshot,
+    findings,
+  });
 }
 
 function resolveSnapshotPath(


### PR DESCRIPTION
Add deterministic exception matching for core policy violations and Nx Conformance findings, and suppress matched findings before signal generation, scoring, and recommendations are computed.

This also refactors governance runs to load raw conformance snapshots before building signals and preserves internal exception application artifacts for later explainability work.

Closes #99 Refs #96 Refs #97 Refs #98