### PR TITLE
feat(nx-governance): surface exception-backed findings in reports

### DIFF
--- a/packages/governance/src/core/models.ts
+++ b/packages/governance/src/core/models.ts
@@ -163,10 +163,49 @@ export interface GovernanceTopIssue {
   sourcePluginId?: string;
 }
 
+export interface GovernanceExceptionSummary {
+  declaredCount: number;
+  matchedCount: number;
+  suppressedPolicyViolationCount: number;
+  suppressedConformanceFindingCount: number;
+  unusedExceptionCount: number;
+}
+
+export interface GovernanceExceptionUsage {
+  id: string;
+  source: 'policy' | 'conformance';
+  reason: string;
+  owner: string;
+  review: import('./exceptions.js').GovernanceExceptionReview;
+  matchCount: number;
+}
+
+export interface GovernanceExceptionFinding {
+  kind: 'policy-violation' | 'conformance-finding';
+  exceptionId: string;
+  source: 'policy' | 'conformance';
+  ruleId?: string;
+  category: GovernanceSignalCategory | 'architecture' | 'documentation';
+  severity: GovernanceSignalSeverity;
+  projectId?: string;
+  targetProjectId?: string;
+  relatedProjectIds: string[];
+  message: string;
+  sourcePluginId?: string;
+}
+
+export interface GovernanceExceptionReport {
+  summary: GovernanceExceptionSummary;
+  used: GovernanceExceptionUsage[];
+  unused: GovernanceExceptionUsage[];
+  suppressedFindings: GovernanceExceptionFinding[];
+}
+
 export interface GovernanceAssessment {
   workspace: GovernanceWorkspace;
   profile: string;
   warnings: string[];
+  exceptions: GovernanceExceptionReport;
   violations: Violation[];
   measurements: Measurement[];
   signalBreakdown: SignalBreakdown;

--- a/packages/governance/src/plugin/build-exception-report.spec.ts
+++ b/packages/governance/src/plugin/build-exception-report.spec.ts
@@ -1,0 +1,156 @@
+import type { GovernanceException } from '../core/index.js';
+import { buildExceptionReport } from './build-exception-report.js';
+import type { GovernanceExceptionApplicationResult } from './apply-governance-exceptions.js';
+
+describe('buildExceptionReport', () => {
+  it('builds deterministic used, unused, and suppressed finding output', () => {
+    const declaredExceptions: GovernanceException[] = [
+      {
+        id: 'z-unused',
+        source: 'conformance',
+        scope: {
+          source: 'conformance',
+          category: 'ownership',
+          projectId: 'payments-feature',
+        },
+        reason: 'Unused exception.',
+        owner: '@org/architecture',
+        review: {
+          expiresAt: '2026-08-01',
+        },
+      },
+      {
+        id: 'a-policy',
+        source: 'policy',
+        scope: {
+          source: 'policy',
+          ruleId: 'domain-boundary',
+          projectId: 'orders-app',
+          targetProjectId: 'shared-util',
+        },
+        reason: 'Active migration.',
+        owner: '@org/architecture',
+        review: {
+          reviewBy: '2026-06-01',
+        },
+      },
+    ];
+
+    const result = buildExceptionReport(
+      makeApplicationResult({
+        declaredExceptions,
+        suppressedPolicyViolations: [
+          {
+            outcome: 'suppressed',
+            matchedExceptionId: 'a-policy',
+            finding: {
+              id: 'orders-shared-domain',
+              ruleId: 'domain-boundary',
+              project: 'orders-app',
+              severity: 'error',
+              category: 'boundary',
+              message: 'Domain boundary violation.',
+              details: {
+                targetProject: 'shared-util',
+              },
+              sourcePluginId: 'policy-plugin',
+            },
+          },
+        ],
+        suppressedConformanceFindings: [
+          {
+            outcome: 'suppressed',
+            matchedExceptionId: 'a-policy',
+            finding: {
+              id: 'finding-1',
+              ruleId: '@nx/conformance/enforce-project-boundaries',
+              category: 'boundary',
+              severity: 'warning',
+              projectId: 'orders-app',
+              relatedProjectIds: ['shared-util', 'orders-app'],
+              message: 'Boundary warning.',
+              metadata: {
+                sourcePluginId: 'conformance-plugin',
+              },
+            },
+          },
+        ],
+      })
+    );
+
+    expect(result.summary).toEqual({
+      declaredCount: 2,
+      matchedCount: 1,
+      suppressedPolicyViolationCount: 1,
+      suppressedConformanceFindingCount: 1,
+      unusedExceptionCount: 1,
+    });
+    expect(result.used).toEqual([
+      {
+        id: 'a-policy',
+        source: 'policy',
+        reason: 'Active migration.',
+        owner: '@org/architecture',
+        review: {
+          reviewBy: '2026-06-01',
+        },
+        matchCount: 2,
+      },
+    ]);
+    expect(result.unused).toEqual([
+      {
+        id: 'z-unused',
+        source: 'conformance',
+        reason: 'Unused exception.',
+        owner: '@org/architecture',
+        review: {
+          expiresAt: '2026-08-01',
+        },
+        matchCount: 0,
+      },
+    ]);
+    expect(result.suppressedFindings).toEqual([
+      {
+        kind: 'policy-violation',
+        exceptionId: 'a-policy',
+        source: 'policy',
+        ruleId: 'domain-boundary',
+        category: 'boundary',
+        severity: 'error',
+        projectId: 'orders-app',
+        targetProjectId: 'shared-util',
+        relatedProjectIds: ['orders-app', 'shared-util'],
+        message: 'Domain boundary violation.',
+        sourcePluginId: 'policy-plugin',
+      },
+      {
+        kind: 'conformance-finding',
+        exceptionId: 'a-policy',
+        source: 'conformance',
+        ruleId: '@nx/conformance/enforce-project-boundaries',
+        category: 'boundary',
+        severity: 'warning',
+        projectId: 'orders-app',
+        relatedProjectIds: ['orders-app', 'shared-util'],
+        message: 'Boundary warning.',
+        sourcePluginId: 'conformance-plugin',
+      },
+    ]);
+  });
+});
+
+function makeApplicationResult(input: {
+  declaredExceptions: GovernanceException[];
+  suppressedPolicyViolations: GovernanceExceptionApplicationResult['suppressedPolicyViolations'];
+  suppressedConformanceFindings: GovernanceExceptionApplicationResult['suppressedConformanceFindings'];
+}): GovernanceExceptionApplicationResult {
+  return {
+    declaredExceptions: input.declaredExceptions,
+    policyViolations: [],
+    conformanceFindings: [],
+    activePolicyViolations: [],
+    suppressedPolicyViolations: input.suppressedPolicyViolations,
+    activeConformanceFindings: [],
+    suppressedConformanceFindings: input.suppressedConformanceFindings,
+  };
+}

--- a/packages/governance/src/plugin/build-exception-report.ts
+++ b/packages/governance/src/plugin/build-exception-report.ts
@@ -1,0 +1,185 @@
+import type {
+  GovernanceExceptionFinding,
+  GovernanceExceptionReport,
+  GovernanceExceptionUsage,
+  Violation,
+} from '../core/index.js';
+import type { ConformanceFinding } from '../conformance-adapter/conformance-adapter.js';
+import type {
+  GovernanceExceptionApplicationResult,
+  GovernanceSuppressedFinding,
+} from './apply-governance-exceptions.js';
+
+const SOURCE_ORDER = {
+  policy: 0,
+  conformance: 1,
+} as const;
+
+const SEVERITY_ORDER = {
+  error: 0,
+  warning: 1,
+  info: 2,
+} as const;
+
+export function buildExceptionReport(
+  application: GovernanceExceptionApplicationResult
+): GovernanceExceptionReport {
+  const usageCounts = countMatchesByExceptionId(application);
+  const suppressedFindings = [
+    ...application.suppressedPolicyViolations.map((entry) =>
+      mapSuppressedPolicyViolation(entry)
+    ),
+    ...application.suppressedConformanceFindings.map((entry) =>
+      mapSuppressedConformanceFinding(entry)
+    ),
+  ].sort(compareSuppressedFindings);
+
+  const used: GovernanceExceptionUsage[] = [];
+  const unused: GovernanceExceptionUsage[] = [];
+
+  for (const exception of [...application.declaredExceptions].sort((a, b) =>
+    a.id.localeCompare(b.id)
+  )) {
+    const matchCount = usageCounts.get(exception.id) ?? 0;
+    const usage = {
+      id: exception.id,
+      source: exception.source,
+      reason: exception.reason,
+      owner: exception.owner,
+      review: { ...exception.review },
+      matchCount,
+    };
+
+    if (matchCount > 0) {
+      used.push(usage);
+    } else {
+      unused.push(usage);
+    }
+  }
+
+  return {
+    summary: {
+      declaredCount: application.declaredExceptions.length,
+      matchedCount: used.length,
+      suppressedPolicyViolationCount:
+        application.suppressedPolicyViolations.length,
+      suppressedConformanceFindingCount:
+        application.suppressedConformanceFindings.length,
+      unusedExceptionCount: unused.length,
+    },
+    used,
+    unused,
+    suppressedFindings,
+  };
+}
+
+function countMatchesByExceptionId(
+  application: GovernanceExceptionApplicationResult
+): Map<string, number> {
+  const counts = new Map<string, number>();
+
+  for (const entry of [
+    ...application.suppressedPolicyViolations,
+    ...application.suppressedConformanceFindings,
+  ]) {
+    counts.set(
+      entry.matchedExceptionId,
+      (counts.get(entry.matchedExceptionId) ?? 0) + 1
+    );
+  }
+
+  return counts;
+}
+
+function mapSuppressedPolicyViolation(
+  entry: GovernanceSuppressedFinding<Violation>
+): GovernanceExceptionFinding {
+  const targetProjectId = asString(entry.finding.details?.targetProject);
+  const projectId = asString(entry.finding.project);
+
+  return {
+    kind: 'policy-violation',
+    exceptionId: entry.matchedExceptionId,
+    source: 'policy',
+    ruleId: entry.finding.ruleId,
+    category: entry.finding.category,
+    severity: entry.finding.severity,
+    ...(projectId ? { projectId } : {}),
+    ...(targetProjectId ? { targetProjectId } : {}),
+    relatedProjectIds: [projectId, targetProjectId].filter(
+      (value): value is string => typeof value === 'string'
+    ),
+    message: entry.finding.message,
+    ...(entry.finding.sourcePluginId
+      ? { sourcePluginId: entry.finding.sourcePluginId }
+      : {}),
+  };
+}
+
+function mapSuppressedConformanceFinding(
+  entry: GovernanceSuppressedFinding<ConformanceFinding>
+): GovernanceExceptionFinding {
+  return {
+    kind: 'conformance-finding',
+    exceptionId: entry.matchedExceptionId,
+    source: 'conformance',
+    ...(entry.finding.ruleId ? { ruleId: entry.finding.ruleId } : {}),
+    category: entry.finding.category,
+    severity: entry.finding.severity,
+    ...(entry.finding.projectId ? { projectId: entry.finding.projectId } : {}),
+    relatedProjectIds: [...entry.finding.relatedProjectIds].sort((a, b) =>
+      a.localeCompare(b)
+    ),
+    message: entry.finding.message,
+    ...(asString(entry.finding.metadata?.sourcePluginId)
+      ? { sourcePluginId: asString(entry.finding.metadata?.sourcePluginId) }
+      : {}),
+  };
+}
+
+function compareSuppressedFindings(
+  left: GovernanceExceptionFinding,
+  right: GovernanceExceptionFinding
+): number {
+  const sourceOrder = SOURCE_ORDER[left.source] - SOURCE_ORDER[right.source];
+  if (sourceOrder !== 0) {
+    return sourceOrder;
+  }
+
+  const severityOrder =
+    SEVERITY_ORDER[left.severity] - SEVERITY_ORDER[right.severity];
+  if (severityOrder !== 0) {
+    return severityOrder;
+  }
+
+  const ruleComparison = (left.ruleId ?? '').localeCompare(right.ruleId ?? '');
+  if (ruleComparison !== 0) {
+    return ruleComparison;
+  }
+
+  const projectScopeComparison = [
+    left.projectId ?? '',
+    left.targetProjectId ?? '',
+    left.relatedProjectIds.join(','),
+  ]
+    .join('|')
+    .localeCompare(
+      [right.projectId ?? '', right.targetProjectId ?? '', right.relatedProjectIds.join(',')].join(
+        '|'
+      )
+    );
+  if (projectScopeComparison !== 0) {
+    return projectScopeComparison;
+  }
+
+  const messageComparison = left.message.localeCompare(right.message);
+  if (messageComparison !== 0) {
+    return messageComparison;
+  }
+
+  return left.exceptionId.localeCompare(right.exceptionId);
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}

--- a/packages/governance/src/plugin/run-governance.spec.ts
+++ b/packages/governance/src/plugin/run-governance.spec.ts
@@ -261,6 +261,25 @@ describe('runGovernance', () => {
     }
   });
 
+  it('returns an empty exception report when no exceptions are declared', async () => {
+    jest.spyOn(logger, 'info').mockImplementation(() => undefined);
+
+    const result = await runGovernance({ reportType: 'health' });
+
+    expect(result.assessment.exceptions).toEqual({
+      summary: {
+        declaredCount: 0,
+        matchedCount: 0,
+        suppressedPolicyViolationCount: 0,
+        suppressedConformanceFindingCount: 0,
+        unusedExceptionCount: 0,
+      },
+      used: [],
+      unused: [],
+      suppressedFindings: [],
+    });
+  });
+
   it('suppresses matching declared exceptions before conformance signals are built', async () => {
     jest.spyOn(logger, 'info').mockImplementation(() => undefined);
 
@@ -335,6 +354,40 @@ describe('runGovernance', () => {
           (entry) => entry.source === 'conformance'
         )
       ).toEqual({ source: 'conformance', count: 1 });
+      expect(withException.assessment.exceptions.summary).toEqual({
+        declaredCount: 1,
+        matchedCount: 1,
+        suppressedPolicyViolationCount: 0,
+        suppressedConformanceFindingCount: 1,
+        unusedExceptionCount: 0,
+      });
+      expect(withException.assessment.exceptions.used).toEqual([
+        {
+          id: 'suppress-conformance-boundary',
+          source: 'conformance',
+          reason: 'Known migration overlap.',
+          owner: '@org/architecture',
+          review: {
+            reviewBy: '2026-06-01',
+          },
+          matchCount: 1,
+        },
+      ]);
+      expect(withException.assessment.exceptions.suppressedFindings).toEqual([
+        expect.objectContaining({
+          kind: 'conformance-finding',
+          exceptionId: 'suppress-conformance-boundary',
+          source: 'conformance',
+          ruleId: '@nx/conformance/enforce-project-boundaries',
+          category: 'boundary',
+          severity: 'error',
+          projectId: 'packages/governance',
+          relatedProjectIds: [
+            'packages/governance-e2e',
+          ],
+          message: 'Suppressed conformance boundary violation',
+        }),
+      ]);
       expect(
         withException.assessment.topIssues.filter(
           (issue) =>
@@ -363,6 +416,67 @@ describe('runGovernance', () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+
+  it('reports declared but unused exceptions without affecting active burden', async () => {
+    jest.spyOn(logger, 'info').mockImplementation(() => undefined);
+
+    const baseline = await runGovernance({ reportType: 'health' });
+    const resolvedOverrides = await loadProfileOverrides(
+      workspaceRoot,
+      'angular-cleanup'
+    );
+    mockedLoadProfileOverrides.mockResolvedValueOnce({
+      ...resolvedOverrides,
+      exceptions: [
+        {
+          id: 'unused-policy-exception',
+          source: 'policy',
+          scope: {
+            source: 'policy',
+            ruleId: 'domain-boundary',
+            projectId: 'missing-project',
+          },
+          reason: 'Reserved for future migration.',
+          owner: '@org/architecture',
+          review: {
+            expiresAt: '2026-08-01',
+          },
+        },
+      ],
+    });
+
+    const withUnusedException = await runGovernance({ reportType: 'health' });
+
+    expect(withUnusedException.assessment.exceptions.summary).toEqual({
+      declaredCount: 1,
+      matchedCount: 0,
+      suppressedPolicyViolationCount: 0,
+      suppressedConformanceFindingCount: 0,
+      unusedExceptionCount: 1,
+    });
+    expect(withUnusedException.assessment.exceptions.used).toEqual([]);
+    expect(withUnusedException.assessment.exceptions.unused).toEqual([
+      {
+        id: 'unused-policy-exception',
+        source: 'policy',
+        reason: 'Reserved for future migration.',
+        owner: '@org/architecture',
+        review: {
+          expiresAt: '2026-08-01',
+        },
+        matchCount: 0,
+      },
+    ]);
+    expect(withUnusedException.assessment.exceptions.suppressedFindings).toEqual(
+      []
+    );
+    expect(withUnusedException.assessment.violations).toEqual(
+      baseline.assessment.violations
+    );
+    expect(withUnusedException.assessment.signalBreakdown).toEqual(
+      baseline.assessment.signalBreakdown
+    );
   });
 
   it('auto-discovers conformance output from nx.json when no override is provided', async () => {

--- a/packages/governance/src/plugin/run-governance.ts
+++ b/packages/governance/src/plugin/run-governance.ts
@@ -82,6 +82,7 @@ import {
 import { applyGovernanceExceptions } from './apply-governance-exceptions.js';
 import type { GovernanceAssessmentArtifacts } from './build-assessment-artifacts.js';
 import type { ConformanceSnapshot } from '../conformance-adapter/conformance-adapter.js';
+import { buildExceptionReport } from './build-exception-report.js';
 
 export interface GovernanceRunOptions {
   profile?: string;
@@ -1603,6 +1604,7 @@ async function buildAssessmentArtifacts(
       workspace: enrichedInventory,
       profile: profileName,
       warnings: overrides.runtimeWarnings,
+      exceptions: buildExceptionReport(exceptionApplication),
       violations: filteredViolations,
       measurements: filteredMeasurements,
       signalBreakdown: buildSignalBreakdown(filteredSignals),

--- a/packages/governance/src/reporting/render-cli.ts
+++ b/packages/governance/src/reporting/render-cli.ts
@@ -43,6 +43,41 @@ export function renderCliReport(assessment: GovernanceAssessment): string {
   }
 
   lines.push('');
+  lines.push('Exceptions:');
+  lines.push(`- declared: ${assessment.exceptions.summary.declaredCount}`);
+  lines.push(`- matched: ${assessment.exceptions.summary.matchedCount}`);
+  lines.push(`- unused: ${assessment.exceptions.summary.unusedExceptionCount}`);
+  lines.push(
+    `- suppressed policy findings: ${assessment.exceptions.summary.suppressedPolicyViolationCount}`
+  );
+  lines.push(
+    `- suppressed conformance findings: ${assessment.exceptions.summary.suppressedConformanceFindingCount}`
+  );
+
+  if (assessment.exceptions.suppressedFindings.length > 0) {
+    lines.push('Suppressed Findings:');
+    for (const finding of assessment.exceptions.suppressedFindings) {
+      const ruleIdSuffix = finding.ruleId ? ` :: ${finding.ruleId}` : '';
+      const projectScope = [
+        finding.projectId,
+        finding.targetProjectId,
+        finding.relatedProjectIds.length > 0
+          ? `related=${finding.relatedProjectIds.join(',')}`
+          : undefined,
+      ]
+        .filter((value): value is string => !!value)
+        .join(' -> ');
+      const projectScopeSuffix = projectScope
+        ? ` :: scope=${projectScope}`
+        : '';
+
+      lines.push(
+        `- ${finding.exceptionId} :: ${finding.source}/${finding.kind} :: [${finding.severity}]${ruleIdSuffix}${projectScopeSuffix} :: ${finding.message}`
+      );
+    }
+  }
+
+  lines.push('');
   lines.push('Metrics:');
 
   for (const metric of assessment.measurements) {

--- a/packages/governance/src/reporting/rendering.spec.ts
+++ b/packages/governance/src/reporting/rendering.spec.ts
@@ -21,6 +21,16 @@ describe('governance report rendering', () => {
     expect(rendered).toContain('Signal Sources:');
     expect(rendered).toContain('Signal Types:');
     expect(rendered).toContain('Signal Severity:');
+    expect(rendered).toContain('Exceptions:');
+    expect(rendered).toContain('- declared: 2');
+    expect(rendered).toContain('- matched: 1');
+    expect(rendered).toContain('- unused: 1');
+    expect(rendered).toContain('- suppressed policy findings: 1');
+    expect(rendered).toContain('- suppressed conformance findings: 1');
+    expect(rendered).toContain('Suppressed Findings:');
+    expect(rendered).toContain(
+      '- suppress-domain :: policy/policy-violation :: [error] :: domain-boundary :: scope=orders-app -> shared-util -> related=orders-app,shared-util :: Suppressed domain boundary violation'
+    );
     expect(rendered).toContain('Metric Families:');
     expect(rendered).toContain('Top Issues:');
     expect(rendered).toContain('- graph: 3');
@@ -43,6 +53,12 @@ describe('governance report rendering', () => {
       rendered.indexOf('Signal Severity:')
     );
     expect(rendered.indexOf('Signal Severity:')).toBeLessThan(
+      rendered.indexOf('Exceptions:')
+    );
+    expect(rendered.indexOf('Exceptions:')).toBeLessThan(
+      rendered.indexOf('Metrics:')
+    );
+    expect(rendered.indexOf('Suppressed Findings:')).toBeLessThan(
       rendered.indexOf('Metrics:')
     );
     expect(rendered.indexOf('Metrics:')).toBeLessThan(
@@ -127,6 +143,64 @@ describe('governance report rendering', () => {
           ],
         },
       },
+      exceptions: {
+        summary: {
+          declaredCount: 2,
+          matchedCount: 1,
+          suppressedPolicyViolationCount: 1,
+          suppressedConformanceFindingCount: 1,
+          unusedExceptionCount: 1,
+        },
+        used: [
+          {
+            id: 'suppress-domain',
+            source: 'policy',
+            reason: 'Known transition.',
+            owner: '@org/architecture',
+            review: {
+              reviewBy: '2026-06-01',
+            },
+            matchCount: 2,
+          },
+        ],
+        unused: [
+          {
+            id: 'unused-owner-gap',
+            source: 'conformance',
+            reason: 'Reserved but currently unmatched.',
+            owner: '@org/architecture',
+            review: {
+              expiresAt: '2026-08-01',
+            },
+            matchCount: 0,
+          },
+        ],
+        suppressedFindings: expect.arrayContaining([
+          {
+            kind: 'policy-violation',
+            exceptionId: 'suppress-domain',
+            source: 'policy',
+            ruleId: 'domain-boundary',
+            category: 'boundary',
+            severity: 'error',
+            projectId: 'orders-app',
+            targetProjectId: 'shared-util',
+            relatedProjectIds: ['orders-app', 'shared-util'],
+            message: 'Suppressed domain boundary violation',
+          },
+          {
+            kind: 'conformance-finding',
+            exceptionId: 'suppress-domain',
+            source: 'conformance',
+            ruleId: '@nx/conformance/enforce-project-boundaries',
+            category: 'boundary',
+            severity: 'warning',
+            projectId: 'orders-app',
+            relatedProjectIds: ['orders-app', 'shared-util'],
+            message: 'Suppressed conformance boundary warning',
+          },
+        ]),
+      },
       signalBreakdown: {
         total: 6,
         bySource: [
@@ -198,6 +272,64 @@ function makeAssessment(): GovernanceAssessment {
     },
     profile: 'angular-cleanup',
     warnings: [],
+    exceptions: {
+      summary: {
+        declaredCount: 2,
+        matchedCount: 1,
+        suppressedPolicyViolationCount: 1,
+        suppressedConformanceFindingCount: 1,
+        unusedExceptionCount: 1,
+      },
+      used: [
+        {
+          id: 'suppress-domain',
+          source: 'policy',
+          reason: 'Known transition.',
+          owner: '@org/architecture',
+          review: {
+            reviewBy: '2026-06-01',
+          },
+          matchCount: 2,
+        },
+      ],
+      unused: [
+        {
+          id: 'unused-owner-gap',
+          source: 'conformance',
+          reason: 'Reserved but currently unmatched.',
+          owner: '@org/architecture',
+          review: {
+            expiresAt: '2026-08-01',
+          },
+          matchCount: 0,
+        },
+      ],
+      suppressedFindings: [
+        {
+          kind: 'policy-violation',
+          exceptionId: 'suppress-domain',
+          source: 'policy',
+          ruleId: 'domain-boundary',
+          category: 'boundary',
+          severity: 'error',
+          projectId: 'orders-app',
+          targetProjectId: 'shared-util',
+          relatedProjectIds: ['orders-app', 'shared-util'],
+          message: 'Suppressed domain boundary violation',
+        },
+        {
+          kind: 'conformance-finding',
+          exceptionId: 'suppress-domain',
+          source: 'conformance',
+          ruleId: '@nx/conformance/enforce-project-boundaries',
+          category: 'boundary',
+          severity: 'warning',
+          projectId: 'orders-app',
+          relatedProjectIds: ['orders-app', 'shared-util'],
+          message: 'Suppressed conformance boundary warning',
+        },
+      ],
+    },
     violations: [],
     measurements: [
       {

--- a/packages/governance/src/snapshot-store/index.spec.ts
+++ b/packages/governance/src/snapshot-store/index.spec.ts
@@ -39,6 +39,18 @@ describe('snapshot-store', () => {
       },
       profile: 'angular-cleanup',
       warnings: [],
+      exceptions: {
+        summary: {
+          declaredCount: 0,
+          matchedCount: 0,
+          suppressedPolicyViolationCount: 0,
+          suppressedConformanceFindingCount: 0,
+          unusedExceptionCount: 0,
+        },
+        used: [],
+        unused: [],
+        suppressedFindings: [],
+      },
       violations: [],
       measurements: [
         {


### PR DESCRIPTION
Add a public exception report section to governance assessments and surface suppressed exception-backed findings in JSON and CLI output.

This keeps active violations, signals, health, and recommendations focused on active governance burden while exposing deterministic exception usage, unused declarations, and suppressed finding detail for explainability.

Closes #100 Refs #96 Refs #99