### PR TITLE
feat(nx-governance): add exception lifecycle and stale debt handling

### DIFF
--- a/packages/governance/src/core/models.ts
+++ b/packages/governance/src/core/models.ts
@@ -169,11 +169,19 @@ export interface GovernanceExceptionSummary {
   suppressedPolicyViolationCount: number;
   suppressedConformanceFindingCount: number;
   unusedExceptionCount: number;
+  activeExceptionCount: number;
+  staleExceptionCount: number;
+  expiredExceptionCount: number;
+  reactivatedPolicyViolationCount: number;
+  reactivatedConformanceFindingCount: number;
 }
+
+export type GovernanceExceptionStatus = 'active' | 'stale' | 'expired';
 
 export interface GovernanceExceptionUsage {
   id: string;
   source: 'policy' | 'conformance';
+  status: GovernanceExceptionStatus;
   reason: string;
   owner: string;
   review: import('./exceptions.js').GovernanceExceptionReview;
@@ -184,6 +192,7 @@ export interface GovernanceExceptionFinding {
   kind: 'policy-violation' | 'conformance-finding';
   exceptionId: string;
   source: 'policy' | 'conformance';
+  status: GovernanceExceptionStatus;
   ruleId?: string;
   category: GovernanceSignalCategory | 'architecture' | 'documentation';
   severity: GovernanceSignalSeverity;
@@ -199,6 +208,7 @@ export interface GovernanceExceptionReport {
   used: GovernanceExceptionUsage[];
   unused: GovernanceExceptionUsage[];
   suppressedFindings: GovernanceExceptionFinding[];
+  reactivatedFindings: GovernanceExceptionFinding[];
 }
 
 export interface GovernanceAssessment {

--- a/packages/governance/src/plugin/apply-governance-exceptions.spec.ts
+++ b/packages/governance/src/plugin/apply-governance-exceptions.spec.ts
@@ -1,5 +1,8 @@
 import type { GovernanceException, Violation } from '../core/index.js';
-import type { ConformanceFinding, ConformanceSnapshot } from '../conformance-adapter/conformance-adapter.js';
+import type {
+  ConformanceFinding,
+  ConformanceSnapshot,
+} from '../conformance-adapter/conformance-adapter.js';
 import {
   buildConformanceSignals,
   buildPolicySignals,
@@ -65,6 +68,7 @@ describe('applyGovernanceExceptions', () => {
       exceptions,
       policyViolations: violations,
       conformanceFindings: [],
+      asOf: new Date('2026-04-17T00:00:00.000Z'),
     });
 
     expect(result.activePolicyViolations).toEqual([]);
@@ -129,6 +133,7 @@ describe('applyGovernanceExceptions', () => {
       ],
       policyViolations: [violation],
       conformanceFindings: [],
+      asOf: new Date('2026-04-17T00:00:00.000Z'),
     });
 
     expect(result.suppressedPolicyViolations).toEqual([
@@ -167,6 +172,7 @@ describe('applyGovernanceExceptions', () => {
       ],
       policyViolations: [],
       conformanceFindings: [finding],
+      asOf: new Date('2026-04-17T00:00:00.000Z'),
     });
 
     expect(result.activeConformanceFindings).toEqual([]);
@@ -178,7 +184,9 @@ describe('applyGovernanceExceptions', () => {
       }),
     ]);
     expect(
-      buildConformanceSignals(makeConformanceSnapshot(result.activeConformanceFindings))
+      buildConformanceSignals(
+        makeConformanceSnapshot(result.activeConformanceFindings)
+      )
     ).toEqual([]);
   });
 
@@ -238,6 +246,7 @@ describe('applyGovernanceExceptions', () => {
       ],
       policyViolations: [],
       conformanceFindings: findings,
+      asOf: new Date('2026-04-17T00:00:00.000Z'),
     });
 
     expect(result.suppressedConformanceFindings).toEqual([
@@ -247,6 +256,87 @@ describe('applyGovernanceExceptions', () => {
       }),
     ]);
     expect(result.activeConformanceFindings).toEqual([findings[1]]);
+  });
+
+  it('reactivates stale and expired exception matches instead of suppressing them', () => {
+    const policyViolation: Violation = {
+      id: 'orders-shared-domain',
+      ruleId: 'domain-boundary',
+      project: 'orders-app',
+      severity: 'error',
+      category: 'boundary',
+      message: 'Domain boundary violation.',
+      details: {
+        targetProject: 'shared-util',
+      },
+    };
+    const conformanceFinding: ConformanceFinding = {
+      id: 'finding-1',
+      ruleId: '@nx/conformance/enforce-project-boundaries',
+      category: 'boundary',
+      severity: 'warning',
+      projectId: 'orders-app',
+      relatedProjectIds: ['shared-util'],
+      message: 'Boundary warning.',
+    };
+
+    const result = applyGovernanceExceptions({
+      exceptions: [
+        {
+          id: 'stale-policy',
+          source: 'policy',
+          scope: {
+            source: 'policy',
+            ruleId: 'domain-boundary',
+            projectId: 'orders-app',
+            targetProjectId: 'shared-util',
+          },
+          reason: 'Needs review.',
+          owner: '@org/architecture',
+          review: {
+            reviewBy: '2026-04-01',
+          },
+        },
+        {
+          id: 'expired-conformance',
+          source: 'conformance',
+          scope: {
+            source: 'conformance',
+            ruleId: '@nx/conformance/enforce-project-boundaries',
+            projectId: 'orders-app',
+          },
+          reason: 'Expired exception.',
+          owner: '@org/architecture',
+          review: {
+            expiresAt: '2026-04-01',
+          },
+        },
+      ],
+      policyViolations: [policyViolation],
+      conformanceFindings: [conformanceFinding],
+      asOf: new Date('2026-04-17T00:00:00.000Z'),
+    });
+
+    expect(result.suppressedPolicyViolations).toEqual([]);
+    expect(result.suppressedConformanceFindings).toEqual([]);
+    expect(result.activePolicyViolations).toEqual([policyViolation]);
+    expect(result.activeConformanceFindings).toEqual([conformanceFinding]);
+    expect(result.reactivatedPolicyViolations).toEqual([
+      expect.objectContaining({
+        finding: policyViolation,
+        matchedExceptionId: 'stale-policy',
+        matchedExceptionStatus: 'stale',
+        outcome: 'active',
+      }),
+    ]);
+    expect(result.reactivatedConformanceFindings).toEqual([
+      expect.objectContaining({
+        finding: conformanceFinding,
+        matchedExceptionId: 'expired-conformance',
+        matchedExceptionStatus: 'expired',
+        outcome: 'active',
+      }),
+    ]);
   });
 });
 

--- a/packages/governance/src/plugin/apply-governance-exceptions.ts
+++ b/packages/governance/src/plugin/apply-governance-exceptions.ts
@@ -1,5 +1,6 @@
 import type {
   GovernanceException,
+  GovernanceExceptionStatus,
   GovernancePolicyExceptionScope,
   GovernanceConformanceExceptionScope,
   Violation,
@@ -10,6 +11,7 @@ import {
   isPolicyExceptionScope,
 } from '../core/index.js';
 import type { ConformanceFinding } from '../conformance-adapter/conformance-adapter.js';
+import { evaluateExceptionLifecycle } from './evaluate-exception-lifecycle.js';
 
 export interface GovernanceExceptionMatch {
   exceptionId: string;
@@ -21,6 +23,7 @@ export interface GovernanceAppliedFinding<T> {
   finding: T;
   outcome: 'active' | 'suppressed';
   matchedExceptionId?: string;
+  matchedExceptionStatus?: GovernanceExceptionStatus;
 }
 
 export interface GovernanceSuppressedFinding<T> {
@@ -31,44 +34,73 @@ export interface GovernanceSuppressedFinding<T> {
 
 export interface GovernanceExceptionApplicationResult {
   declaredExceptions: GovernanceException[];
+  exceptionStatuses: Record<string, GovernanceExceptionStatus>;
   policyViolations: GovernanceAppliedFinding<Violation>[];
   conformanceFindings: GovernanceAppliedFinding<ConformanceFinding>[];
   activePolicyViolations: Violation[];
   suppressedPolicyViolations: GovernanceSuppressedFinding<Violation>[];
+  reactivatedPolicyViolations: GovernanceAppliedFinding<Violation>[];
   activeConformanceFindings: ConformanceFinding[];
   suppressedConformanceFindings: GovernanceSuppressedFinding<ConformanceFinding>[];
+  reactivatedConformanceFindings: GovernanceAppliedFinding<ConformanceFinding>[];
 }
 
 export interface ApplyGovernanceExceptionsInput {
   exceptions: GovernanceException[];
   policyViolations: Violation[];
   conformanceFindings: ConformanceFinding[];
+  asOf: Date;
 }
 
 export function applyGovernanceExceptions(
   input: ApplyGovernanceExceptionsInput
 ): GovernanceExceptionApplicationResult {
+  const lifecycles = input.exceptions.map((exception) =>
+    evaluateExceptionLifecycle(exception, input.asOf)
+  );
+  const exceptionStatuses = Object.fromEntries(
+    lifecycles.map((entry) => [entry.exception.id, entry.status])
+  ) as Record<string, GovernanceExceptionStatus>;
+  const activeExceptions = lifecycles
+    .filter((entry) => entry.status === 'active')
+    .map((entry) => entry.exception);
+  const inactiveExceptions = lifecycles.filter(
+    (entry) => entry.status !== 'active'
+  );
+
   const policyViolations = input.policyViolations.map((violation) =>
-    applyPolicyException(violation, input.exceptions)
+    applyPolicyException(violation, activeExceptions)
   );
   const conformanceFindings = input.conformanceFindings.map((finding) =>
-    applyConformanceException(finding, input.exceptions)
+    applyConformanceException(finding, activeExceptions)
   );
+  const reactivatedPolicyViolations = input.policyViolations
+    .map((violation) =>
+      findLifecycleMatchedPolicyViolation(violation, inactiveExceptions)
+    )
+    .filter(isPresent);
+  const reactivatedConformanceFindings = input.conformanceFindings
+    .map((finding) =>
+      findLifecycleMatchedConformanceFinding(finding, inactiveExceptions)
+    )
+    .filter(isPresent);
 
   return {
     declaredExceptions: [...input.exceptions],
+    exceptionStatuses,
     policyViolations,
     conformanceFindings,
     activePolicyViolations: policyViolations
       .filter((entry) => entry.outcome === 'active')
       .map((entry) => entry.finding),
     suppressedPolicyViolations: policyViolations.filter(isSuppressedFinding),
+    reactivatedPolicyViolations,
     activeConformanceFindings: conformanceFindings
       .filter((entry) => entry.outcome === 'active')
       .map((entry) => entry.finding),
-    suppressedConformanceFindings: conformanceFindings.filter(
-      isSuppressedFinding
-    ),
+    suppressedConformanceFindings:
+      conformanceFindings.filter(isSuppressedFinding),
+    reactivatedConformanceFindings,
   };
 }
 
@@ -103,6 +135,7 @@ function applyPolicyException(
     finding: violation,
     outcome: 'suppressed',
     matchedExceptionId: bestMatch.exceptionId,
+    matchedExceptionStatus: 'active',
   };
 }
 
@@ -137,6 +170,73 @@ function applyConformanceException(
     finding,
     outcome: 'suppressed',
     matchedExceptionId: bestMatch.exceptionId,
+    matchedExceptionStatus: 'active',
+  };
+}
+
+function findLifecycleMatchedPolicyViolation(
+  violation: Violation,
+  lifecycles: ReturnType<typeof evaluateExceptionLifecycle>[]
+): GovernanceAppliedFinding<Violation> | undefined {
+  const bestMatch = selectBestMatch(
+    lifecycles
+      .filter((entry) => entry.exception.source === 'policy')
+      .flatMap((entry) => {
+        const match = matchPolicyException(entry.exception.scope, violation);
+        return match
+          ? [
+              {
+                ...match,
+                exceptionId: entry.exception.id,
+                status: entry.status,
+              },
+            ]
+          : [];
+      })
+  );
+
+  if (!bestMatch || bestMatch.status === 'active') {
+    return undefined;
+  }
+
+  return {
+    finding: violation,
+    outcome: 'active',
+    matchedExceptionId: bestMatch.exceptionId,
+    matchedExceptionStatus: bestMatch.status,
+  };
+}
+
+function findLifecycleMatchedConformanceFinding(
+  finding: ConformanceFinding,
+  lifecycles: ReturnType<typeof evaluateExceptionLifecycle>[]
+): GovernanceAppliedFinding<ConformanceFinding> | undefined {
+  const bestMatch = selectBestMatch(
+    lifecycles
+      .filter((entry) => entry.exception.source === 'conformance')
+      .flatMap((entry) => {
+        const match = matchConformanceException(entry.exception.scope, finding);
+        return match
+          ? [
+              {
+                ...match,
+                exceptionId: entry.exception.id,
+                status: entry.status,
+              },
+            ]
+          : [];
+      })
+  );
+
+  if (!bestMatch || bestMatch.status === 'active') {
+    return undefined;
+  }
+
+  return {
+    finding,
+    outcome: 'active',
+    matchedExceptionId: bestMatch.exceptionId,
+    matchedExceptionStatus: bestMatch.status,
   };
 }
 
@@ -150,7 +250,10 @@ function matchPolicyException(
 
   const targetProjectId = normalizeText(violation.details?.targetProject);
 
-  if (scope.ruleId !== violation.ruleId || scope.projectId !== violation.project) {
+  if (
+    scope.ruleId !== violation.ruleId ||
+    scope.projectId !== violation.project
+  ) {
     return null;
   }
 
@@ -186,7 +289,10 @@ function matchConformanceException(
 
   if (
     scope.relatedProjectIds &&
-    !areEqualRelatedProjectIds(scope.relatedProjectIds, finding.relatedProjectIds)
+    !areEqualRelatedProjectIds(
+      scope.relatedProjectIds,
+      finding.relatedProjectIds
+    )
   ) {
     return null;
   }
@@ -198,8 +304,14 @@ function matchConformanceException(
 }
 
 function selectBestMatch(
-  matches: GovernanceExceptionMatch[]
-): GovernanceExceptionMatch | null {
+  matches: (GovernanceExceptionMatch & {
+    status?: GovernanceExceptionStatus;
+  })[]
+):
+  | (GovernanceExceptionMatch & {
+      status?: GovernanceExceptionStatus;
+    })
+  | null {
   if (matches.length === 0) {
     return null;
   }
@@ -238,10 +350,7 @@ function getConformanceSpecificity(
   ].filter(Boolean).length;
 }
 
-function areEqualRelatedProjectIds(
-  left: string[],
-  right: string[]
-): boolean {
+function areEqualRelatedProjectIds(left: string[], right: string[]): boolean {
   const normalizedLeft = normalizeRelatedProjectIds(left);
   const normalizedRight = normalizeRelatedProjectIds(right);
 
@@ -255,7 +364,7 @@ function areEqualRelatedProjectIds(
 }
 
 function normalizeRelatedProjectIds(projectIds: string[]): string[] {
-  return [...new Set(projectIds.map(normalizeText).filter(isDefined))].sort(
+  return [...new Set(projectIds.map(normalizeText).filter(isPresent))].sort(
     (left, right) => left.localeCompare(right)
   );
 }
@@ -269,7 +378,7 @@ function normalizeText(value: unknown): string | undefined {
   return normalized.length > 0 ? normalized : undefined;
 }
 
-function isDefined<T>(value: T | undefined): value is T {
+function isPresent<T>(value: T | undefined): value is T {
   return value !== undefined;
 }
 

--- a/packages/governance/src/plugin/build-exception-report.spec.ts
+++ b/packages/governance/src/plugin/build-exception-report.spec.ts
@@ -84,11 +84,17 @@ describe('buildExceptionReport', () => {
       suppressedPolicyViolationCount: 1,
       suppressedConformanceFindingCount: 1,
       unusedExceptionCount: 1,
+      activeExceptionCount: 2,
+      staleExceptionCount: 0,
+      expiredExceptionCount: 0,
+      reactivatedPolicyViolationCount: 0,
+      reactivatedConformanceFindingCount: 0,
     });
     expect(result.used).toEqual([
       {
         id: 'a-policy',
         source: 'policy',
+        status: 'active',
         reason: 'Active migration.',
         owner: '@org/architecture',
         review: {
@@ -101,6 +107,7 @@ describe('buildExceptionReport', () => {
       {
         id: 'z-unused',
         source: 'conformance',
+        status: 'active',
         reason: 'Unused exception.',
         owner: '@org/architecture',
         review: {
@@ -114,6 +121,7 @@ describe('buildExceptionReport', () => {
         kind: 'policy-violation',
         exceptionId: 'a-policy',
         source: 'policy',
+        status: 'active',
         ruleId: 'domain-boundary',
         category: 'boundary',
         severity: 'error',
@@ -127,6 +135,7 @@ describe('buildExceptionReport', () => {
         kind: 'conformance-finding',
         exceptionId: 'a-policy',
         source: 'conformance',
+        status: 'active',
         ruleId: '@nx/conformance/enforce-project-boundaries',
         category: 'boundary',
         severity: 'warning',
@@ -136,6 +145,7 @@ describe('buildExceptionReport', () => {
         sourcePluginId: 'conformance-plugin',
       },
     ]);
+    expect(result.reactivatedFindings).toEqual([]);
   });
 });
 
@@ -146,11 +156,16 @@ function makeApplicationResult(input: {
 }): GovernanceExceptionApplicationResult {
   return {
     declaredExceptions: input.declaredExceptions,
+    exceptionStatuses: Object.fromEntries(
+      input.declaredExceptions.map((exception) => [exception.id, 'active'])
+    ) as GovernanceExceptionApplicationResult['exceptionStatuses'],
     policyViolations: [],
     conformanceFindings: [],
     activePolicyViolations: [],
     suppressedPolicyViolations: input.suppressedPolicyViolations,
+    reactivatedPolicyViolations: [],
     activeConformanceFindings: [],
     suppressedConformanceFindings: input.suppressedConformanceFindings,
+    reactivatedConformanceFindings: [],
   };
 }

--- a/packages/governance/src/plugin/build-exception-report.ts
+++ b/packages/governance/src/plugin/build-exception-report.ts
@@ -25,12 +25,29 @@ export function buildExceptionReport(
   application: GovernanceExceptionApplicationResult
 ): GovernanceExceptionReport {
   const usageCounts = countMatchesByExceptionId(application);
+  const activeExceptionCount = Object.values(
+    application.exceptionStatuses
+  ).filter((status) => status === 'active').length;
+  const staleExceptionCount = Object.values(
+    application.exceptionStatuses
+  ).filter((status) => status === 'stale').length;
+  const expiredExceptionCount = Object.values(
+    application.exceptionStatuses
+  ).filter((status) => status === 'expired').length;
   const suppressedFindings = [
     ...application.suppressedPolicyViolations.map((entry) =>
       mapSuppressedPolicyViolation(entry)
     ),
     ...application.suppressedConformanceFindings.map((entry) =>
       mapSuppressedConformanceFinding(entry)
+    ),
+  ].sort(compareSuppressedFindings);
+  const reactivatedFindings = [
+    ...application.reactivatedPolicyViolations.map((entry) =>
+      mapReactivatedPolicyViolation(entry)
+    ),
+    ...application.reactivatedConformanceFindings.map((entry) =>
+      mapReactivatedConformanceFinding(entry)
     ),
   ].sort(compareSuppressedFindings);
 
@@ -44,6 +61,7 @@ export function buildExceptionReport(
     const usage = {
       id: exception.id,
       source: exception.source,
+      status: application.exceptionStatuses[exception.id],
       reason: exception.reason,
       owner: exception.owner,
       review: { ...exception.review },
@@ -66,10 +84,18 @@ export function buildExceptionReport(
       suppressedConformanceFindingCount:
         application.suppressedConformanceFindings.length,
       unusedExceptionCount: unused.length,
+      activeExceptionCount,
+      staleExceptionCount,
+      expiredExceptionCount,
+      reactivatedPolicyViolationCount:
+        application.reactivatedPolicyViolations.length,
+      reactivatedConformanceFindingCount:
+        application.reactivatedConformanceFindings.length,
     },
     used,
     unused,
     suppressedFindings,
+    reactivatedFindings,
   };
 }
 
@@ -81,11 +107,19 @@ function countMatchesByExceptionId(
   for (const entry of [
     ...application.suppressedPolicyViolations,
     ...application.suppressedConformanceFindings,
+    ...application.reactivatedPolicyViolations.filter(
+      (finding) => typeof finding.matchedExceptionId === 'string'
+    ),
+    ...application.reactivatedConformanceFindings.filter(
+      (finding) => typeof finding.matchedExceptionId === 'string'
+    ),
   ]) {
-    counts.set(
-      entry.matchedExceptionId,
-      (counts.get(entry.matchedExceptionId) ?? 0) + 1
-    );
+    if (entry.matchedExceptionId) {
+      counts.set(
+        entry.matchedExceptionId,
+        (counts.get(entry.matchedExceptionId) ?? 0) + 1
+      );
+    }
   }
 
   return counts;
@@ -104,6 +138,7 @@ function mapSuppressedPolicyViolation(
     ruleId: entry.finding.ruleId,
     category: entry.finding.category,
     severity: entry.finding.severity,
+    status: 'active',
     ...(projectId ? { projectId } : {}),
     ...(targetProjectId ? { targetProjectId } : {}),
     relatedProjectIds: [projectId, targetProjectId].filter(
@@ -123,6 +158,55 @@ function mapSuppressedConformanceFinding(
     kind: 'conformance-finding',
     exceptionId: entry.matchedExceptionId,
     source: 'conformance',
+    ...(entry.finding.ruleId ? { ruleId: entry.finding.ruleId } : {}),
+    category: entry.finding.category,
+    severity: entry.finding.severity,
+    status: 'active',
+    ...(entry.finding.projectId ? { projectId: entry.finding.projectId } : {}),
+    relatedProjectIds: [...entry.finding.relatedProjectIds].sort((a, b) =>
+      a.localeCompare(b)
+    ),
+    message: entry.finding.message,
+    ...(asString(entry.finding.metadata?.sourcePluginId)
+      ? { sourcePluginId: asString(entry.finding.metadata?.sourcePluginId) }
+      : {}),
+  };
+}
+
+function mapReactivatedPolicyViolation(
+  entry: GovernanceExceptionApplicationResult['reactivatedPolicyViolations'][number]
+): GovernanceExceptionFinding {
+  const targetProjectId = asString(entry.finding.details?.targetProject);
+  const projectId = asString(entry.finding.project);
+
+  return {
+    kind: 'policy-violation',
+    exceptionId: entry.matchedExceptionId ?? 'unknown-exception',
+    source: 'policy',
+    status: entry.matchedExceptionStatus ?? 'stale',
+    ruleId: entry.finding.ruleId,
+    category: entry.finding.category,
+    severity: entry.finding.severity,
+    ...(projectId ? { projectId } : {}),
+    ...(targetProjectId ? { targetProjectId } : {}),
+    relatedProjectIds: [targetProjectId].filter(
+      (value): value is string => typeof value === 'string'
+    ),
+    message: entry.finding.message,
+    ...(entry.finding.sourcePluginId
+      ? { sourcePluginId: entry.finding.sourcePluginId }
+      : {}),
+  };
+}
+
+function mapReactivatedConformanceFinding(
+  entry: GovernanceExceptionApplicationResult['reactivatedConformanceFindings'][number]
+): GovernanceExceptionFinding {
+  return {
+    kind: 'conformance-finding',
+    exceptionId: entry.matchedExceptionId ?? 'unknown-exception',
+    source: 'conformance',
+    status: entry.matchedExceptionStatus ?? 'stale',
     ...(entry.finding.ruleId ? { ruleId: entry.finding.ruleId } : {}),
     category: entry.finding.category,
     severity: entry.finding.severity,
@@ -164,9 +248,11 @@ function compareSuppressedFindings(
   ]
     .join('|')
     .localeCompare(
-      [right.projectId ?? '', right.targetProjectId ?? '', right.relatedProjectIds.join(',')].join(
-        '|'
-      )
+      [
+        right.projectId ?? '',
+        right.targetProjectId ?? '',
+        right.relatedProjectIds.join(','),
+      ].join('|')
     );
   if (projectScopeComparison !== 0) {
     return projectScopeComparison;

--- a/packages/governance/src/plugin/evaluate-exception-lifecycle.spec.ts
+++ b/packages/governance/src/plugin/evaluate-exception-lifecycle.spec.ts
@@ -1,0 +1,87 @@
+import type { GovernanceException } from '../core/index.js';
+import { evaluateExceptionLifecycle } from './evaluate-exception-lifecycle.js';
+
+describe('evaluateExceptionLifecycle', () => {
+  const asOf = new Date('2026-04-17T00:00:00.000Z');
+
+  it('classifies exceptions with future reviewBy as active', () => {
+    expect(
+      evaluateExceptionLifecycle(
+        makeException({
+          review: {
+            reviewBy: '2026-05-01',
+          },
+        }),
+        asOf
+      )
+    ).toMatchObject({
+      status: 'active',
+    });
+  });
+
+  it('classifies exceptions with past reviewBy as stale', () => {
+    expect(
+      evaluateExceptionLifecycle(
+        makeException({
+          review: {
+            reviewBy: '2026-04-01',
+          },
+        }),
+        asOf
+      )
+    ).toMatchObject({
+      status: 'stale',
+    });
+  });
+
+  it('classifies exceptions with past expiresAt as expired', () => {
+    expect(
+      evaluateExceptionLifecycle(
+        makeException({
+          review: {
+            expiresAt: '2026-04-01',
+          },
+        }),
+        asOf
+      )
+    ).toMatchObject({
+      status: 'expired',
+    });
+  });
+
+  it('prefers expired over stale when both dates are in the past', () => {
+    expect(
+      evaluateExceptionLifecycle(
+        makeException({
+          review: {
+            reviewBy: '2026-04-01',
+            expiresAt: '2026-04-10',
+          },
+        }),
+        asOf
+      )
+    ).toMatchObject({
+      status: 'expired',
+    });
+  });
+});
+
+function makeException(
+  input: Partial<GovernanceException>
+): GovernanceException {
+  return {
+    id: 'exception-id',
+    source: 'policy',
+    scope: {
+      source: 'policy',
+      ruleId: 'domain-boundary',
+      projectId: 'orders-app',
+    },
+    reason: 'Test exception.',
+    owner: '@org/architecture',
+    review: {
+      reviewBy: '2026-06-01',
+    },
+    ...input,
+  };
+}

--- a/packages/governance/src/plugin/evaluate-exception-lifecycle.ts
+++ b/packages/governance/src/plugin/evaluate-exception-lifecycle.ts
@@ -1,0 +1,51 @@
+import type { GovernanceException } from '../core/index.js';
+
+export type GovernanceExceptionStatus = 'active' | 'stale' | 'expired';
+
+export interface GovernanceExceptionLifecycle {
+  exception: GovernanceException;
+  status: GovernanceExceptionStatus;
+}
+
+export function evaluateExceptionLifecycle(
+  exception: GovernanceException,
+  asOf: Date
+): GovernanceExceptionLifecycle {
+  const asOfMs = asOf.getTime();
+
+  const expiresAtMs = parseLifecycleDate(exception.review.expiresAt);
+  if (expiresAtMs !== undefined && expiresAtMs < asOfMs) {
+    return {
+      exception,
+      status: 'expired',
+    };
+  }
+
+  const reviewByMs = parseLifecycleDate(exception.review.reviewBy);
+  if (reviewByMs !== undefined && reviewByMs < asOfMs) {
+    return {
+      exception,
+      status: 'stale',
+    };
+  }
+
+  return {
+    exception,
+    status: 'active',
+  };
+}
+
+function parseLifecycleDate(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const normalized = value.includes('T') ? value : `${value}T00:00:00.000Z`;
+  const timestamp = Date.parse(normalized);
+
+  if (!Number.isFinite(timestamp)) {
+    throw new Error(`Invalid governance exception lifecycle date "${value}".`);
+  }
+
+  return timestamp;
+}

--- a/packages/governance/src/plugin/run-governance.spec.ts
+++ b/packages/governance/src/plugin/run-governance.spec.ts
@@ -39,7 +39,9 @@ import {
 const actualProfileModule = jest.requireActual(
   '../presets/angular-cleanup/profile.js'
 ) as typeof import('../presets/angular-cleanup/profile.js');
-const mockedLoadProfileOverrides = jest.mocked(profileModule.loadProfileOverrides);
+const mockedLoadProfileOverrides = jest.mocked(
+  profileModule.loadProfileOverrides
+);
 
 describe('runGovernance', () => {
   function writeSnapshotFile(
@@ -57,6 +59,7 @@ describe('runGovernance', () => {
     mockedLoadProfileOverrides.mockImplementation(
       actualProfileModule.loadProfileOverrides
     );
+    jest.useRealTimers();
   });
 
   it('keeps report measurement ids stable across report types after signal-based metric wiring', async () => {
@@ -273,10 +276,16 @@ describe('runGovernance', () => {
         suppressedPolicyViolationCount: 0,
         suppressedConformanceFindingCount: 0,
         unusedExceptionCount: 0,
+        activeExceptionCount: 0,
+        staleExceptionCount: 0,
+        expiredExceptionCount: 0,
+        reactivatedPolicyViolationCount: 0,
+        reactivatedConformanceFindingCount: 0,
       },
       used: [],
       unused: [],
       suppressedFindings: [],
+      reactivatedFindings: [],
     });
   });
 
@@ -339,6 +348,7 @@ describe('runGovernance', () => {
     });
 
     try {
+      jest.useFakeTimers().setSystemTime(new Date('2026-04-17T00:00:00.000Z'));
       const withException = await runGovernance({
         reportType: 'health',
         conformanceJson,
@@ -360,11 +370,17 @@ describe('runGovernance', () => {
         suppressedPolicyViolationCount: 0,
         suppressedConformanceFindingCount: 1,
         unusedExceptionCount: 0,
+        activeExceptionCount: 1,
+        staleExceptionCount: 0,
+        expiredExceptionCount: 0,
+        reactivatedPolicyViolationCount: 0,
+        reactivatedConformanceFindingCount: 0,
       });
       expect(withException.assessment.exceptions.used).toEqual([
         {
           id: 'suppress-conformance-boundary',
           source: 'conformance',
+          status: 'active',
           reason: 'Known migration overlap.',
           owner: '@org/architecture',
           review: {
@@ -378,16 +394,18 @@ describe('runGovernance', () => {
           kind: 'conformance-finding',
           exceptionId: 'suppress-conformance-boundary',
           source: 'conformance',
+          status: 'active',
           ruleId: '@nx/conformance/enforce-project-boundaries',
           category: 'boundary',
           severity: 'error',
           projectId: 'packages/governance',
-          relatedProjectIds: [
-            'packages/governance-e2e',
-          ],
+          relatedProjectIds: ['packages/governance-e2e'],
           message: 'Suppressed conformance boundary violation',
         }),
       ]);
+      expect(withException.assessment.exceptions.reactivatedFindings).toEqual(
+        []
+      );
       expect(
         withException.assessment.topIssues.filter(
           (issue) =>
@@ -454,12 +472,18 @@ describe('runGovernance', () => {
       suppressedPolicyViolationCount: 0,
       suppressedConformanceFindingCount: 0,
       unusedExceptionCount: 1,
+      activeExceptionCount: 1,
+      staleExceptionCount: 0,
+      expiredExceptionCount: 0,
+      reactivatedPolicyViolationCount: 0,
+      reactivatedConformanceFindingCount: 0,
     });
     expect(withUnusedException.assessment.exceptions.used).toEqual([]);
     expect(withUnusedException.assessment.exceptions.unused).toEqual([
       {
         id: 'unused-policy-exception',
         source: 'policy',
+        status: 'active',
         reason: 'Reserved for future migration.',
         owner: '@org/architecture',
         review: {
@@ -468,15 +492,121 @@ describe('runGovernance', () => {
         matchCount: 0,
       },
     ]);
-    expect(withUnusedException.assessment.exceptions.suppressedFindings).toEqual(
-      []
-    );
+    expect(
+      withUnusedException.assessment.exceptions.suppressedFindings
+    ).toEqual([]);
+    expect(
+      withUnusedException.assessment.exceptions.reactivatedFindings
+    ).toEqual([]);
     expect(withUnusedException.assessment.violations).toEqual(
       baseline.assessment.violations
     );
     expect(withUnusedException.assessment.signalBreakdown).toEqual(
       baseline.assessment.signalBreakdown
     );
+  });
+
+  it('reactivates findings when exceptions are stale or expired', async () => {
+    jest.spyOn(logger, 'info').mockImplementation(() => undefined);
+    jest.useFakeTimers().setSystemTime(new Date('2026-04-17T00:00:00.000Z'));
+
+    const tempDir = mkdtempSync(
+      path.join(tmpdir(), 'nx-governance-conformance-')
+    );
+    const conformanceJson = path.join(tempDir, 'conformance.json');
+
+    writeFileSync(
+      conformanceJson,
+      JSON.stringify([
+        {
+          id: 'stale-finding',
+          ruleId: '@nx/conformance/enforce-project-boundaries',
+          severity: 'error',
+          message: 'Reactivated conformance boundary violation',
+          projectId: 'packages/governance',
+          relatedProjectIds: ['packages/governance-e2e'],
+        },
+      ])
+    );
+
+    const resolvedOverrides = await loadProfileOverrides(
+      workspaceRoot,
+      'angular-cleanup'
+    );
+    mockedLoadProfileOverrides.mockResolvedValueOnce({
+      ...resolvedOverrides,
+      exceptions: [
+        {
+          id: 'stale-conformance-boundary',
+          source: 'conformance',
+          scope: {
+            source: 'conformance',
+            ruleId: '@nx/conformance/enforce-project-boundaries',
+            projectId: 'packages/governance',
+          },
+          reason: 'Needs review.',
+          owner: '@org/architecture',
+          review: {
+            reviewBy: '2026-04-01',
+          },
+        },
+      ],
+    });
+
+    try {
+      const result = await runGovernance({
+        reportType: 'health',
+        conformanceJson,
+      });
+
+      expect(
+        result.assessment.signalBreakdown.bySource.find(
+          (entry) => entry.source === 'conformance'
+        )
+      ).toEqual({ source: 'conformance', count: 1 });
+      expect(result.assessment.exceptions.summary).toEqual({
+        declaredCount: 1,
+        matchedCount: 1,
+        suppressedPolicyViolationCount: 0,
+        suppressedConformanceFindingCount: 0,
+        unusedExceptionCount: 0,
+        activeExceptionCount: 0,
+        staleExceptionCount: 1,
+        expiredExceptionCount: 0,
+        reactivatedPolicyViolationCount: 0,
+        reactivatedConformanceFindingCount: 1,
+      });
+      expect(result.assessment.exceptions.used).toEqual([
+        {
+          id: 'stale-conformance-boundary',
+          source: 'conformance',
+          status: 'stale',
+          reason: 'Needs review.',
+          owner: '@org/architecture',
+          review: {
+            reviewBy: '2026-04-01',
+          },
+          matchCount: 1,
+        },
+      ]);
+      expect(result.assessment.exceptions.suppressedFindings).toEqual([]);
+      expect(result.assessment.exceptions.reactivatedFindings).toEqual([
+        expect.objectContaining({
+          kind: 'conformance-finding',
+          exceptionId: 'stale-conformance-boundary',
+          source: 'conformance',
+          status: 'stale',
+          ruleId: '@nx/conformance/enforce-project-boundaries',
+          category: 'boundary',
+          severity: 'error',
+          projectId: 'packages/governance',
+          relatedProjectIds: ['packages/governance-e2e'],
+          message: 'Reactivated conformance boundary violation',
+        }),
+      ]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('auto-discovers conformance output from nx.json when no override is provided', async () => {

--- a/packages/governance/src/plugin/run-governance.ts
+++ b/packages/governance/src/plugin/run-governance.ts
@@ -262,6 +262,10 @@ const AI_PAYLOAD_LIMITS = {
   scorecardDeltas: 12,
 };
 
+interface GovernanceAssessmentArtifactsOptions {
+  asOf?: Date;
+}
+
 export async function runGovernance(
   options: GovernanceRunOptions = {}
 ): Promise<GovernanceRunResult> {
@@ -1459,7 +1463,8 @@ async function buildAssessment(
 }
 
 async function buildAssessmentArtifacts(
-  options: GovernanceRunOptions
+  options: GovernanceRunOptions,
+  artifactsOptions: GovernanceAssessmentArtifactsOptions = {}
 ): Promise<GovernanceAssessmentArtifacts> {
   const profileName = options.profile ?? 'angular-cleanup';
 
@@ -1515,6 +1520,7 @@ async function buildAssessmentArtifacts(
     exceptions: overrides.exceptions,
     policyViolations: coreViolations,
     conformanceFindings: conformanceSnapshot?.findings ?? [],
+    asOf: artifactsOptions.asOf ?? new Date(),
   });
   const extensionViolations = await evaluateGovernanceRulePacks(
     extensionRegistry,

--- a/packages/governance/src/reporting/render-cli.ts
+++ b/packages/governance/src/reporting/render-cli.ts
@@ -47,11 +47,22 @@ export function renderCliReport(assessment: GovernanceAssessment): string {
   lines.push(`- declared: ${assessment.exceptions.summary.declaredCount}`);
   lines.push(`- matched: ${assessment.exceptions.summary.matchedCount}`);
   lines.push(`- unused: ${assessment.exceptions.summary.unusedExceptionCount}`);
+  lines.push(`- active: ${assessment.exceptions.summary.activeExceptionCount}`);
+  lines.push(`- stale: ${assessment.exceptions.summary.staleExceptionCount}`);
+  lines.push(
+    `- expired: ${assessment.exceptions.summary.expiredExceptionCount}`
+  );
   lines.push(
     `- suppressed policy findings: ${assessment.exceptions.summary.suppressedPolicyViolationCount}`
   );
   lines.push(
     `- suppressed conformance findings: ${assessment.exceptions.summary.suppressedConformanceFindingCount}`
+  );
+  lines.push(
+    `- reactivated policy findings: ${assessment.exceptions.summary.reactivatedPolicyViolationCount}`
+  );
+  lines.push(
+    `- reactivated conformance findings: ${assessment.exceptions.summary.reactivatedConformanceFindingCount}`
   );
 
   if (assessment.exceptions.suppressedFindings.length > 0) {
@@ -72,7 +83,30 @@ export function renderCliReport(assessment: GovernanceAssessment): string {
         : '';
 
       lines.push(
-        `- ${finding.exceptionId} :: ${finding.source}/${finding.kind} :: [${finding.severity}]${ruleIdSuffix}${projectScopeSuffix} :: ${finding.message}`
+        `- ${finding.exceptionId} :: ${finding.status} :: ${finding.source}/${finding.kind} :: [${finding.severity}]${ruleIdSuffix}${projectScopeSuffix} :: ${finding.message}`
+      );
+    }
+  }
+
+  if (assessment.exceptions.reactivatedFindings.length > 0) {
+    lines.push('Reactivated Findings:');
+    for (const finding of assessment.exceptions.reactivatedFindings) {
+      const ruleIdSuffix = finding.ruleId ? ` :: ${finding.ruleId}` : '';
+      const projectScope = [
+        finding.projectId,
+        finding.targetProjectId,
+        finding.relatedProjectIds.length > 0
+          ? `related=${finding.relatedProjectIds.join(',')}`
+          : undefined,
+      ]
+        .filter((value): value is string => !!value)
+        .join(' -> ');
+      const projectScopeSuffix = projectScope
+        ? ` :: scope=${projectScope}`
+        : '';
+
+      lines.push(
+        `- ${finding.exceptionId} :: ${finding.status} :: ${finding.source}/${finding.kind} :: [${finding.severity}]${ruleIdSuffix}${projectScopeSuffix} :: ${finding.message}`
       );
     }
   }

--- a/packages/governance/src/reporting/rendering.spec.ts
+++ b/packages/governance/src/reporting/rendering.spec.ts
@@ -22,14 +22,23 @@ describe('governance report rendering', () => {
     expect(rendered).toContain('Signal Types:');
     expect(rendered).toContain('Signal Severity:');
     expect(rendered).toContain('Exceptions:');
-    expect(rendered).toContain('- declared: 2');
-    expect(rendered).toContain('- matched: 1');
+    expect(rendered).toContain('- declared: 3');
+    expect(rendered).toContain('- matched: 2');
     expect(rendered).toContain('- unused: 1');
+    expect(rendered).toContain('- active: 1');
+    expect(rendered).toContain('- stale: 1');
+    expect(rendered).toContain('- expired: 1');
     expect(rendered).toContain('- suppressed policy findings: 1');
     expect(rendered).toContain('- suppressed conformance findings: 1');
+    expect(rendered).toContain('- reactivated policy findings: 1');
+    expect(rendered).toContain('- reactivated conformance findings: 0');
     expect(rendered).toContain('Suppressed Findings:');
     expect(rendered).toContain(
-      '- suppress-domain :: policy/policy-violation :: [error] :: domain-boundary :: scope=orders-app -> shared-util -> related=orders-app,shared-util :: Suppressed domain boundary violation'
+      '- suppress-domain :: active :: policy/policy-violation :: [error] :: domain-boundary :: scope=orders-app -> shared-util -> related=orders-app,shared-util :: Suppressed domain boundary violation'
+    );
+    expect(rendered).toContain('Reactivated Findings:');
+    expect(rendered).toContain(
+      '- stale-owner-gap :: stale :: policy/policy-violation :: [warning] :: ownership-presence :: scope=payments-feature :: Reactivated ownership gap'
     );
     expect(rendered).toContain('Metric Families:');
     expect(rendered).toContain('Top Issues:');
@@ -145,16 +154,22 @@ describe('governance report rendering', () => {
       },
       exceptions: {
         summary: {
-          declaredCount: 2,
-          matchedCount: 1,
+          declaredCount: 3,
+          matchedCount: 2,
           suppressedPolicyViolationCount: 1,
           suppressedConformanceFindingCount: 1,
           unusedExceptionCount: 1,
+          activeExceptionCount: 1,
+          staleExceptionCount: 1,
+          expiredExceptionCount: 1,
+          reactivatedPolicyViolationCount: 1,
+          reactivatedConformanceFindingCount: 0,
         },
         used: [
           {
             id: 'suppress-domain',
             source: 'policy',
+            status: 'active',
             reason: 'Known transition.',
             owner: '@org/architecture',
             review: {
@@ -162,15 +177,27 @@ describe('governance report rendering', () => {
             },
             matchCount: 2,
           },
+          {
+            id: 'stale-owner-gap',
+            source: 'policy',
+            status: 'stale',
+            reason: 'Needs review.',
+            owner: '@org/architecture',
+            review: {
+              reviewBy: '2026-04-01',
+            },
+            matchCount: 1,
+          },
         ],
         unused: [
           {
             id: 'unused-owner-gap',
             source: 'conformance',
+            status: 'expired',
             reason: 'Reserved but currently unmatched.',
             owner: '@org/architecture',
             review: {
-              expiresAt: '2026-08-01',
+              expiresAt: '2026-03-01',
             },
             matchCount: 0,
           },
@@ -180,6 +207,7 @@ describe('governance report rendering', () => {
             kind: 'policy-violation',
             exceptionId: 'suppress-domain',
             source: 'policy',
+            status: 'active',
             ruleId: 'domain-boundary',
             category: 'boundary',
             severity: 'error',
@@ -192,6 +220,7 @@ describe('governance report rendering', () => {
             kind: 'conformance-finding',
             exceptionId: 'suppress-domain',
             source: 'conformance',
+            status: 'active',
             ruleId: '@nx/conformance/enforce-project-boundaries',
             category: 'boundary',
             severity: 'warning',
@@ -200,6 +229,20 @@ describe('governance report rendering', () => {
             message: 'Suppressed conformance boundary warning',
           },
         ]),
+        reactivatedFindings: [
+          {
+            kind: 'policy-violation',
+            exceptionId: 'stale-owner-gap',
+            source: 'policy',
+            status: 'stale',
+            ruleId: 'ownership-presence',
+            category: 'ownership',
+            severity: 'warning',
+            projectId: 'payments-feature',
+            relatedProjectIds: [],
+            message: 'Reactivated ownership gap',
+          },
+        ],
       },
       signalBreakdown: {
         total: 6,
@@ -274,16 +317,22 @@ function makeAssessment(): GovernanceAssessment {
     warnings: [],
     exceptions: {
       summary: {
-        declaredCount: 2,
-        matchedCount: 1,
+        declaredCount: 3,
+        matchedCount: 2,
         suppressedPolicyViolationCount: 1,
         suppressedConformanceFindingCount: 1,
         unusedExceptionCount: 1,
+        activeExceptionCount: 1,
+        staleExceptionCount: 1,
+        expiredExceptionCount: 1,
+        reactivatedPolicyViolationCount: 1,
+        reactivatedConformanceFindingCount: 0,
       },
       used: [
         {
           id: 'suppress-domain',
           source: 'policy',
+          status: 'active',
           reason: 'Known transition.',
           owner: '@org/architecture',
           review: {
@@ -291,15 +340,27 @@ function makeAssessment(): GovernanceAssessment {
           },
           matchCount: 2,
         },
+        {
+          id: 'stale-owner-gap',
+          source: 'policy',
+          status: 'stale',
+          reason: 'Needs review.',
+          owner: '@org/architecture',
+          review: {
+            reviewBy: '2026-04-01',
+          },
+          matchCount: 1,
+        },
       ],
       unused: [
         {
           id: 'unused-owner-gap',
           source: 'conformance',
+          status: 'expired',
           reason: 'Reserved but currently unmatched.',
           owner: '@org/architecture',
           review: {
-            expiresAt: '2026-08-01',
+            expiresAt: '2026-03-01',
           },
           matchCount: 0,
         },
@@ -309,6 +370,7 @@ function makeAssessment(): GovernanceAssessment {
           kind: 'policy-violation',
           exceptionId: 'suppress-domain',
           source: 'policy',
+          status: 'active',
           ruleId: 'domain-boundary',
           category: 'boundary',
           severity: 'error',
@@ -321,12 +383,27 @@ function makeAssessment(): GovernanceAssessment {
           kind: 'conformance-finding',
           exceptionId: 'suppress-domain',
           source: 'conformance',
+          status: 'active',
           ruleId: '@nx/conformance/enforce-project-boundaries',
           category: 'boundary',
           severity: 'warning',
           projectId: 'orders-app',
           relatedProjectIds: ['orders-app', 'shared-util'],
           message: 'Suppressed conformance boundary warning',
+        },
+      ],
+      reactivatedFindings: [
+        {
+          kind: 'policy-violation',
+          exceptionId: 'stale-owner-gap',
+          source: 'policy',
+          status: 'stale',
+          ruleId: 'ownership-presence',
+          category: 'ownership',
+          severity: 'warning',
+          projectId: 'payments-feature',
+          relatedProjectIds: [],
+          message: 'Reactivated ownership gap',
         },
       ],
     },


### PR DESCRIPTION
Classify governance exceptions as active, stale, or expired against a deterministic evaluation timestamp, and stop stale or expired exceptions from suppressing findings.

This reactivates matched findings as active governance burden, extends the public exception report with lifecycle status and reactivated findings, and updates CLI/JSON output to explain exception debt without changing snapshot storage semantics.

Closes #101 Refs #96 Refs #99 Refs #100