### PR TITLE
test(nx-governance): finalize exception docs and end-to-end coverage

### DIFF
--- a/packages/governance/ARCHITECTURE.md
+++ b/packages/governance/ARCHITECTURE.md
@@ -115,6 +115,17 @@ runGovernance
 
 This preserves one governance truth even when multiple ecosystem engines contribute analysis.
 
+Exception-backed findings already have explicit report shapes in the core
+assessment model:
+
+- `suppressedFindings` for active, tolerated deviations
+- `reactivatedFindings` for stale or expired exception debt
+
+Future Governance Graph work should reuse those shapes directly so
+suppressed deviations stay explainable and reactivated findings stay
+visible as governance debt. Graph visualization remains out of scope for
+the current exception implementation.
+
 ## 6. Module structure
 
 The core package lives under:

--- a/packages/governance/README.md
+++ b/packages/governance/README.md
@@ -21,6 +21,7 @@ Large Nx monorepos accumulate structural debt silently: cross-domain imports sli
 - [Concepts](#concepts)
   - [Profiles](#profiles)
   - [Boundary policy source](#boundary-policy-source)
+  - [Exceptions](#exceptions)
   - [Domain tags](#domain-tags)
   - [Layer tags](#layer-tags)
   - [Ownership signals](#ownership-signals)
@@ -152,6 +153,69 @@ Every profile has a `boundaryPolicySource` setting:
 | `"eslint"`  | The runtime helper `tools/governance/eslint/dependency-constraints.mjs` is loaded at assessment time and its merged constraints are used as the primary rule set. The profile map acts as a fallback/override layer. A warning is surfaced in every report. |
 
 Use `"eslint"` when you want ESLint's `@nx/enforce-module-boundaries` and the governance report to share a single source of truth, eliminating drift between the two enforcement layers.
+
+### Exceptions
+
+Profiles can declare explicit governance exceptions in the same
+`tools/governance/profiles/<name>.json` file used for the rest of the
+workspace policy.
+
+Use exceptions when a known deviation must remain visible and reviewable
+instead of being hidden inside generic overrides.
+
+```jsonc
+{
+  "exceptions": [
+    {
+      "id": "orders-shared-transition",
+      "source": "policy",
+      "scope": {
+        "source": "policy",
+        "ruleId": "domain-boundary",
+        "projectId": "orders-app",
+        "targetProjectId": "shared-util"
+      },
+      "reason": "Temporary migration path during extraction.",
+      "owner": "@org/architecture",
+      "review": {
+        "reviewBy": "2026-06-01"
+      }
+    },
+    {
+      "id": "nx-owner-warning-review",
+      "source": "conformance",
+      "scope": {
+        "source": "conformance",
+        "ruleId": "@nx/conformance/ensure-owners",
+        "projectId": "orders-app"
+      },
+      "reason": "Ownership handoff in progress.",
+      "owner": "@org/architecture",
+      "review": {
+        "expiresAt": "2026-07-01"
+      }
+    }
+  ]
+}
+```
+
+Practical fields:
+
+- `id`: stable identifier used in reports
+- `source`: `policy` or `conformance`
+- `scope`: exact finding scope to match
+- `reason`: why the deviation is tolerated for now
+- `owner`: who is accountable for review/removal
+- `review.reviewBy` / `review.expiresAt`: the lifecycle boundary for the exception
+
+Runtime semantics:
+
+- `active` exceptions suppress matching findings
+- `stale` exceptions no longer suppress; their matched findings become active governance debt again
+- `expired` exceptions no longer suppress; their matched findings also become active governance debt again
+
+Exception-backed findings stay explainable in reports through
+`assessment.exceptions` instead of being silently dropped.
 
 ### Domain tags
 
@@ -759,6 +823,17 @@ Each violation carries:
 | `details`        | Structured data (source/target domain, layer order, dependency type).          |
 | `recommendation` | Actionable guidance for resolving the violation.                               |
 
+Active governance burden remains in `violations`. Exception-backed
+findings that are currently suppressed do not appear here; they are
+reported separately under `assessment.exceptions.suppressedFindings`.
+
+When an exception becomes `stale` or `expired`, its matched finding is no
+longer suppressed and returns to the active report surfaces
+(`violations`, `signalBreakdown`, `topIssues`, `health`, and
+recommendations). The corresponding exception context is retained in
+`assessment.exceptions.reactivatedFindings` so the debt remains
+explainable.
+
 ### Recommendations
 
 Recommendations are generated automatically from the violation and metric set:
@@ -863,6 +938,63 @@ When `--output=json` is used, the full `GovernanceAssessment` is written to stdo
       ]
     }
   },
+  "exceptions": {
+    "summary": {
+      "declaredCount": 2,
+      "matchedCount": 2,
+      "suppressedPolicyViolationCount": 1,
+      "suppressedConformanceFindingCount": 0,
+      "unusedExceptionCount": 0,
+      "activeExceptionCount": 1,
+      "staleExceptionCount": 1,
+      "expiredExceptionCount": 0,
+      "reactivatedPolicyViolationCount": 1,
+      "reactivatedConformanceFindingCount": 0
+    },
+    "used": [
+      {
+        "id": "orders-shared-transition",
+        "source": "policy",
+        "status": "active",
+        "reason": "Temporary migration path during extraction.",
+        "owner": "@org/architecture",
+        "review": {
+          "reviewBy": "2026-06-01"
+        },
+        "matchCount": 1
+      }
+    ],
+    "unused": [],
+    "suppressedFindings": [
+      {
+        "kind": "policy-violation",
+        "exceptionId": "orders-shared-transition",
+        "source": "policy",
+        "status": "active",
+        "ruleId": "domain-boundary",
+        "category": "boundary",
+        "severity": "error",
+        "projectId": "orders-app",
+        "targetProjectId": "shared-util",
+        "relatedProjectIds": ["orders-app", "shared-util"],
+        "message": "Known transition dependency."
+      }
+    ],
+    "reactivatedFindings": [
+      {
+        "kind": "conformance-finding",
+        "exceptionId": "nx-owner-warning-review",
+        "source": "conformance",
+        "status": "stale",
+        "ruleId": "@nx/conformance/ensure-owners",
+        "category": "ownership",
+        "severity": "warning",
+        "projectId": "orders-app",
+        "relatedProjectIds": [],
+        "message": "Ownership warning needs review."
+      }
+    ]
+  },
   "recommendations": [
     {
       "id": "reduce-cross-domain-dependencies",
@@ -919,6 +1051,39 @@ When `--output=json` is used, the full `GovernanceAssessment` is written to stdo
     "documentationCompletenessWeight": 0.2,
     "layerIntegrityWeight": 0.2
   },
+
+  // Explicit exceptions for known, reviewable deviations.
+  "exceptions": [
+    {
+      "id": "orders-shared-transition",
+      "source": "policy",
+      "scope": {
+        "source": "policy",
+        "ruleId": "domain-boundary",
+        "projectId": "orders-app",
+        "targetProjectId": "shared-util"
+      },
+      "reason": "Temporary migration path during extraction.",
+      "owner": "@org/architecture",
+      "review": {
+        "reviewBy": "2026-06-01"
+      }
+    },
+    {
+      "id": "nx-owner-warning-review",
+      "source": "conformance",
+      "scope": {
+        "source": "conformance",
+        "category": "ownership",
+        "projectId": "orders-app"
+      },
+      "reason": "Ownership handoff in progress.",
+      "owner": "@org/architecture",
+      "review": {
+        "expiresAt": "2026-07-01"
+      }
+    }
+  ],
 
   // Per-project overrides — useful for projects that cannot carry tags or metadata
   "projectOverrides": {

--- a/packages/governance/src/plugin/run-governance.spec.ts
+++ b/packages/governance/src/plugin/run-governance.spec.ts
@@ -22,6 +22,8 @@ import {
   angularCleanupProfile,
   loadProfileOverrides,
 } from '../presets/angular-cleanup/profile.js';
+import { renderCliReport } from '../reporting/render-cli.js';
+import { renderJsonReport } from '../reporting/render-json.js';
 import type {
   GovernanceExtensionHost,
   GovernanceMetricProviderInput,
@@ -605,6 +607,236 @@ describe('runGovernance', () => {
         }),
       ]);
     } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('loads declared exceptions from a real profile file and keeps assessment plus rendered output aligned', async () => {
+    jest.spyOn(logger, 'info').mockImplementation(() => undefined);
+    jest.useFakeTimers().setSystemTime(new Date('2026-04-17T00:00:00.000Z'));
+
+    const tempDir = mkdtempSync(
+      path.join(tmpdir(), 'nx-governance-exceptions-e2e-')
+    );
+    const conformanceJson = path.join(tempDir, 'conformance.json');
+    const profilePath = path.join(
+      workspaceRoot,
+      'tools/governance/profiles/issue-102-e2e.json'
+    );
+
+    writeFileSync(
+      conformanceJson,
+      JSON.stringify([
+        {
+          id: 'active-boundary-finding',
+          ruleId: '@nx/conformance/enforce-project-boundaries',
+          severity: 'error',
+          message: 'Suppressed conformance boundary violation',
+          projectId: 'packages/governance',
+          relatedProjectIds: ['packages/governance', 'packages/governance-e2e'],
+        },
+        {
+          id: 'stale-owner-finding',
+          ruleId: '@nx/conformance/ensure-owners',
+          severity: 'warning',
+          message: 'Reactivated conformance ownership warning',
+          projectId: 'packages/governance',
+        },
+      ])
+    );
+    writeFileSync(
+      profilePath,
+      `${JSON.stringify(
+        {
+          exceptions: [
+            {
+              id: 'stale-owner-gap',
+              source: 'conformance',
+              scope: {
+                source: 'conformance',
+                ruleId: '@nx/conformance/ensure-owners',
+                projectId: 'packages/governance',
+              },
+              reason: 'Needs review.',
+              owner: '@org/architecture',
+              review: {
+                reviewBy: '2026-04-01',
+              },
+            },
+            {
+              id: 'suppress-boundary',
+              source: 'conformance',
+              scope: {
+                source: 'conformance',
+                ruleId: '@nx/conformance/enforce-project-boundaries',
+                projectId: 'packages/governance',
+              },
+              reason: 'Known transition.',
+              owner: '@org/architecture',
+              review: {
+                reviewBy: '2026-06-01',
+              },
+            },
+            {
+              id: 'unused-expired-gap',
+              source: 'policy',
+              scope: {
+                source: 'policy',
+                ruleId: 'ownership-presence',
+                projectId: 'missing-project',
+              },
+              reason: 'Leftover waiver to remove.',
+              owner: '@org/architecture',
+              review: {
+                expiresAt: '2026-03-01',
+              },
+            },
+          ],
+        },
+        null,
+        2
+      )}\n`
+    );
+
+    try {
+      const result = await runGovernance({
+        profile: 'issue-102-e2e',
+        reportType: 'health',
+        conformanceJson,
+      });
+
+      expect(result.assessment.exceptions.summary).toEqual({
+        declaredCount: 3,
+        matchedCount: 2,
+        suppressedPolicyViolationCount: 0,
+        suppressedConformanceFindingCount: 1,
+        unusedExceptionCount: 1,
+        activeExceptionCount: 1,
+        staleExceptionCount: 1,
+        expiredExceptionCount: 1,
+        reactivatedPolicyViolationCount: 0,
+        reactivatedConformanceFindingCount: 1,
+      });
+      expect(result.assessment.exceptions.used).toEqual([
+        {
+          id: 'stale-owner-gap',
+          source: 'conformance',
+          status: 'stale',
+          reason: 'Needs review.',
+          owner: '@org/architecture',
+          review: {
+            reviewBy: '2026-04-01',
+          },
+          matchCount: 1,
+        },
+        {
+          id: 'suppress-boundary',
+          source: 'conformance',
+          status: 'active',
+          reason: 'Known transition.',
+          owner: '@org/architecture',
+          review: {
+            reviewBy: '2026-06-01',
+          },
+          matchCount: 1,
+        },
+      ]);
+      expect(result.assessment.exceptions.unused).toEqual([
+        {
+          id: 'unused-expired-gap',
+          source: 'policy',
+          status: 'expired',
+          reason: 'Leftover waiver to remove.',
+          owner: '@org/architecture',
+          review: {
+            expiresAt: '2026-03-01',
+          },
+          matchCount: 0,
+        },
+      ]);
+      expect(result.assessment.exceptions.suppressedFindings).toEqual([
+        expect.objectContaining({
+          kind: 'conformance-finding',
+          exceptionId: 'suppress-boundary',
+          status: 'active',
+          ruleId: '@nx/conformance/enforce-project-boundaries',
+          projectId: 'packages/governance',
+          relatedProjectIds: ['packages/governance-e2e'],
+          message: 'Suppressed conformance boundary violation',
+        }),
+      ]);
+      expect(result.assessment.exceptions.reactivatedFindings).toEqual([
+        expect.objectContaining({
+          kind: 'conformance-finding',
+          exceptionId: 'stale-owner-gap',
+          status: 'stale',
+          ruleId: '@nx/conformance/ensure-owners',
+          projectId: 'packages/governance',
+          relatedProjectIds: [],
+          message: 'Reactivated conformance ownership warning',
+        }),
+      ]);
+
+      const cliReport = renderCliReport(result.assessment);
+      expect(cliReport).toContain('Exceptions:');
+      expect(cliReport).toContain('- declared: 3');
+      expect(cliReport).toContain('- active: 1');
+      expect(cliReport).toContain('- stale: 1');
+      expect(cliReport).toContain('- expired: 1');
+      expect(cliReport).toContain('- suppressed conformance findings: 1');
+      expect(cliReport).toContain('- reactivated conformance findings: 1');
+      expect(cliReport).toContain(
+        '- suppress-boundary :: active :: conformance/conformance-finding :: [error] :: @nx/conformance/enforce-project-boundaries :: scope=packages/governance -> related=packages/governance-e2e :: Suppressed conformance boundary violation'
+      );
+      expect(cliReport).toContain(
+        '- stale-owner-gap :: stale :: conformance/conformance-finding :: [warning] :: @nx/conformance/ensure-owners :: scope=packages/governance :: Reactivated conformance ownership warning'
+      );
+
+      expect(JSON.parse(renderJsonReport(result.assessment))).toMatchObject({
+        profile: 'issue-102-e2e',
+        exceptions: {
+          summary: {
+            declaredCount: 3,
+            matchedCount: 2,
+            suppressedConformanceFindingCount: 1,
+            unusedExceptionCount: 1,
+            activeExceptionCount: 1,
+            staleExceptionCount: 1,
+            expiredExceptionCount: 1,
+            reactivatedConformanceFindingCount: 1,
+          },
+          used: [
+            {
+              id: 'stale-owner-gap',
+              status: 'stale',
+            },
+            {
+              id: 'suppress-boundary',
+              status: 'active',
+            },
+          ],
+          unused: [
+            {
+              id: 'unused-expired-gap',
+              status: 'expired',
+            },
+          ],
+          suppressedFindings: [
+            {
+              exceptionId: 'suppress-boundary',
+              status: 'active',
+            },
+          ],
+          reactivatedFindings: [
+            {
+              exceptionId: 'stale-owner-gap',
+              status: 'stale',
+            },
+          ],
+        },
+      });
+    } finally {
+      rmSync(profilePath, { force: true });
       rmSync(tempDir, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
Add an end-to-end governance exception regression that exercises real profile loading, lifecycle handling, and aligned CLI/JSON reporting.

Also document exception declaration, evaluation semantics, output interpretation, and Governance Graph follow-up guidance in the governance README and architecture docs.

Closes #102 Refs #96 Refs #97 Refs #98 Refs #99 Refs #100 Refs #101