### PR TITLE
feat(skills): add repo-local ai skills

### DIFF
--- a/skills/monitor-ci/SKILL.md
+++ b/skills/monitor-ci/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: monitor-ci
+description: troubleshoot ci, workflow, build, test, lint, nx packaging, generator, executor, inference, or release failures in anarchitecture-plugins. use when a github action, nx target, plugin test, or package validation flow fails and the task is specifically about diagnosing and fixing that repo while preserving deterministic plugin behavior and backward compatibility.
+---
+
+# Overview
+Use this skill when CI or automation is failing in `anarchitecture-plugins`.
+
+Inspect these sources first when relevant:
+
+- workflow logs and failed job output
+- `AGENTS.md`
+- `README.md`
+- affected plugin `README.md`
+
+## Required workflow
+1. Identify the failing workflow, job, package, and Nx target.
+2. Reduce the failure to the smallest reproducible command.
+3. Fix the root cause while preserving plugin design principles.
+4. Validate with package-manager-prefixed Nx commands.
+5. Summarize the root cause, fix, validation, and any migration or compatibility implications.
+
+## Repo-specific checks
+- Do not bypass tests or inference behavior just to make CI green.
+- Keep executors thin and deterministic.
+- Keep generators idempotent and non-destructive.
+- If the fix changes user-facing plugin behavior, say whether migration support and docs updates are required.

--- a/skills/monitor-ci/agents/openai.yaml
+++ b/skills/monitor-ci/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: Plugins Monitor CI
+  short_description: Diagnose and fix CI, Nx, plugin test, and release failures in the plugins repo.

--- a/skills/plugins-generator-author/SKILL.md
+++ b/skills/plugins-generator-author/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: plugins-generator-author
+description: implement and refactor code in anarchitecture-plugins. use when work belongs specifically in the nx plugins repo, especially for generators, executors, project crystal inference, package documentation, tests for plugin behavior, and preserving the repo principles around thin executors, idempotent generators, and backward-compatible plugin evolution.
+---
+
+# Overview
+Use this skill when the task belongs in `anarchitecture-plugins`.
+
+Before changing code, inspect these repo files when relevant:
+
+- `AGENTS.md`
+- `README.md`
+- affected package `README.md`
+- plugin package source under `packages/`
+
+## Core implementation rules
+- Prefer inference (`createNodesV2`) when behavior can be derived from conventions.
+- Keep executors thin, deterministic, and tool-adapter focused.
+- Keep generators idempotent, minimal, and non-destructive.
+- Preserve backward compatibility first; when behavior changes, include migration support and docs.
+- Ship tests and docs with every user-facing change.
+
+## Required workflow
+1. Identify the target plugin package under `packages/`.
+2. Determine whether the task belongs in generator, executor, inference, shared utility, or docs.
+3. Implement the smallest coherent change.
+4. Add or update tests for generator, executor, or inference behavior.
+5. Validate using package-manager-prefixed Nx commands.
+6. Summarize the changed plugin surface, validation, and any migration implications.
+
+## Generator-specific guidance
+- Do not overwrite existing config destructively.
+- Merge configuration and preserve user changes where possible.
+- Keep defaults architecture-aware and convention-first.
+
+## Output expectations
+In the final summary, explicitly report:
+- affected plugin package
+- whether generators, executors, or inference behavior changed
+- whether backward compatibility is preserved
+- whether migration logic or docs updates are required

--- a/skills/plugins-generator-author/agents/openai.yaml
+++ b/skills/plugins-generator-author/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: Plugins Generator Author
+  short_description: Implement generators, executors, and inference in the Nx plugins repo while preserving plugin standards.


### PR DESCRIPTION
## Summary

Add repo-local AI skills to `anarchitecture-plugins`.

## Added skills

- `skills/plugins-generator-author`
- `skills/monitor-ci`

## Notes

These skills are repo-local and do not assume an MCP server exists yet.
They are intended to guide plugin authoring and CI troubleshooting specifically for the plugins repo.
