### PR TITLE
refactor(nx-governance): Refactor inventory normalization to consume the Core-owned adapter result contract instead of importing Nx adapter snapshot types directly.

### DIFF
--- a/packages/governance/eslint.config.mjs
+++ b/packages/governance/eslint.config.mjs
@@ -195,16 +195,18 @@ export default [
     files: ['src/inventory/build-inventory.ts'],
     ignores: governanceCoreCandidateIgnores,
     rules: {
-      // Temporary exception for #248. Inventory still accepts Nx adapter
-      // snapshot types directly.
       'no-restricted-imports': [
         'error',
         {
           patterns: [
             {
-              group: governanceCoreHostForbiddenImports,
+              group: [
+                ...governanceCoreHostForbiddenImports,
+                '../nx-adapter',
+                '../nx-adapter/*',
+              ],
               message:
-                'Inventory normalization must not depend on Nx host modules. See docs/governance/internal-core-boundary.md.',
+                'Inventory normalization must not depend on Nx adapter or Nx host modules. See docs/governance/internal-core-boundary.md.',
             },
           ],
         },

--- a/packages/governance/src/core/core-fixture-coverage.spec.ts
+++ b/packages/governance/src/core/core-fixture-coverage.spec.ts
@@ -1,4 +1,5 @@
 import type {
+  GovernanceWorkspaceAdapterResult,
   GovernanceSignal,
   GovernanceSignalCategory,
   GovernanceSignalSeverity,
@@ -6,6 +7,7 @@ import type {
   GovernanceSignalType,
 } from './index.js';
 import {
+  coreTestAdapterResult,
   coreTestWorkspace,
   coreTestWorkspaceWithDanglingDependency,
   findDanglingDependencies,
@@ -62,7 +64,30 @@ describe('Core signal contracts', () => {
 });
 
 describe('Core adapter contract coverage', () => {
-  it.todo(
-    'creates adapter result fixtures through the Core boundary once #247 lands in this branch'
-  );
+  it('supports plain adapter result data through the core boundary', () => {
+    const adapterResult: GovernanceWorkspaceAdapterResult = {
+      ...coreTestAdapterResult,
+      capabilities: [
+        {
+          id: 'capability:test-fixture',
+          version: '1',
+          data: {
+            origin: 'core-fixture',
+          },
+        },
+      ],
+      diagnostics: [
+        {
+          code: 'fixture-warning',
+          message: 'Fixture diagnostic',
+          source: 'test',
+        },
+      ],
+    };
+
+    expect(adapterResult.projects).toHaveLength(3);
+    expect(adapterResult.dependencies).toHaveLength(2);
+    expect(adapterResult.capabilities?.[0]?.id).toBe('capability:test-fixture');
+    expect(adapterResult.diagnostics?.[0]?.code).toBe('fixture-warning');
+  });
 });

--- a/packages/governance/src/core/testing/workspace.fixtures.ts
+++ b/packages/governance/src/core/testing/workspace.fixtures.ts
@@ -1,6 +1,9 @@
 import type {
+  GovernanceDependencyInput,
   GovernanceDependency,
+  GovernanceProjectInput,
   GovernanceProject,
+  GovernanceWorkspaceAdapterResult,
   GovernanceWorkspace,
   Ownership,
 } from '../index.js';
@@ -76,6 +79,64 @@ export const coreTestWorkspace = {
   projects: coreTestProjects,
   dependencies: coreTestDependencies,
 } satisfies GovernanceWorkspace;
+
+export const coreTestAdapterProjects = [
+  {
+    id: 'booking-ui',
+    root: 'libs/booking/ui',
+    type: 'library',
+    tags: ['scope:booking', 'layer:ui', 'type:ui'],
+    metadata: {
+      documentation: true,
+    },
+  },
+  {
+    id: 'booking-domain',
+    root: 'libs/booking/domain',
+    type: 'library',
+    tags: ['scope:booking', 'layer:domain', 'type:domain'],
+    ownership: {
+      contacts: ['@booking-team'],
+      source: 'codeowners',
+    },
+    metadata: {
+      ownership: {
+        team: 'booking-team',
+      },
+    },
+  },
+  {
+    id: 'platform-shell',
+    root: 'apps/platform-shell',
+    type: 'application',
+    tags: ['scope:platform', 'layer:app', 'type:app'],
+    ownership: {
+      contacts: ['@platform-team'],
+      source: 'codeowners',
+    },
+    metadata: {},
+  },
+] satisfies GovernanceProjectInput[];
+
+export const coreTestAdapterDependencies = [
+  {
+    sourceProjectId: 'booking-ui',
+    targetProjectId: 'booking-domain',
+    type: 'static',
+  },
+  {
+    sourceProjectId: 'platform-shell',
+    targetProjectId: 'booking-ui',
+    type: 'static',
+    sourceFile: 'apps/platform-shell/src/main.ts',
+  },
+] satisfies GovernanceDependencyInput[];
+
+export const coreTestAdapterResult = {
+  workspaceRoot: '/virtual/workspace',
+  projects: coreTestAdapterProjects,
+  dependencies: coreTestAdapterDependencies,
+} satisfies GovernanceWorkspaceAdapterResult;
 
 export const coreTestWorkspaceWithDanglingDependency = {
   id: 'edge-workspace',

--- a/packages/governance/src/inventory/build-inventory.spec.ts
+++ b/packages/governance/src/inventory/build-inventory.spec.ts
@@ -1,0 +1,140 @@
+import type { GovernanceWorkspaceAdapterResult } from '../core/index.js';
+import { coreTestAdapterResult } from '../core/testing/workspace.fixtures.js';
+
+import { buildInventory } from './build-inventory.js';
+
+describe('buildInventory', () => {
+  it('builds inventory from a core-owned adapter result', () => {
+    const inventory = buildInventory(coreTestAdapterResult, {
+      projectOverrides: {},
+    });
+
+    expect(inventory).toMatchObject({
+      id: 'workspace',
+      name: 'workspace',
+      root: '/virtual/workspace',
+    });
+    expect(inventory.projects.map((project) => project.id)).toEqual([
+      'booking-ui',
+      'booking-domain',
+      'platform-shell',
+    ]);
+    expect(inventory.dependencies).toEqual([
+      {
+        source: 'booking-ui',
+        target: 'booking-domain',
+        type: 'static',
+      },
+      {
+        source: 'platform-shell',
+        target: 'booking-ui',
+        type: 'static',
+        sourceFile: 'apps/platform-shell/src/main.ts',
+      },
+    ]);
+  });
+
+  it('preserves tag-derived domain and layer mapping', () => {
+    const inventory = buildInventory(coreTestAdapterResult, {
+      projectOverrides: {},
+    });
+
+    expect(inventory.projects).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'booking-ui',
+          tags: ['scope:booking', 'layer:ui', 'type:ui'],
+          domain: 'booking',
+          layer: 'ui',
+        }),
+        expect.objectContaining({
+          id: 'booking-domain',
+          tags: ['scope:booking', 'layer:domain', 'type:domain'],
+          domain: 'booking',
+          layer: 'domain',
+        }),
+      ])
+    );
+  });
+
+  it('preserves ownership merge behavior and project overrides', () => {
+    const adapterResult: GovernanceWorkspaceAdapterResult = {
+      workspaceRoot: '/virtual/workspace',
+      projects: [
+        {
+          id: 'inventory-app',
+          root: 'apps/inventory-app',
+          type: 'application',
+          tags: ['scope:inventory', 'layer:app'],
+          metadata: {
+            ownership: {
+              team: 'inventory-team',
+            },
+          },
+          ownership: {
+            contacts: ['@inventory-owners'],
+            source: 'codeowners',
+          },
+        },
+        {
+          id: 'inventory-docs',
+          root: 'libs/inventory/docs',
+          type: 'library',
+          tags: ['scope:inventory', 'layer:docs'],
+          metadata: {},
+        },
+      ],
+      dependencies: [
+        {
+          sourceProjectId: 'inventory-app',
+          targetProjectId: 'inventory-docs',
+          type: 'dynamic',
+        },
+      ],
+    };
+
+    const inventory = buildInventory(adapterResult, {
+      projectOverrides: {
+        'inventory-docs': {
+          domain: 'inventory',
+          layer: 'documentation',
+          ownershipTeam: 'docs-team',
+          documentation: false,
+        },
+      },
+    });
+
+    expect(inventory.projects).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'inventory-app',
+          ownership: {
+            team: 'inventory-team',
+            contacts: ['@inventory-owners'],
+            source: 'merged',
+          },
+        }),
+        expect.objectContaining({
+          id: 'inventory-docs',
+          domain: 'inventory',
+          layer: 'documentation',
+          ownership: {
+            team: 'docs-team',
+            contacts: [],
+            source: 'project-metadata',
+          },
+          metadata: {
+            documentation: false,
+          },
+        }),
+      ])
+    );
+    expect(inventory.dependencies).toEqual([
+      {
+        source: 'inventory-app',
+        target: 'inventory-docs',
+        type: 'dynamic',
+      },
+    ]);
+  });
+});

--- a/packages/governance/src/inventory/build-inventory.ts
+++ b/packages/governance/src/inventory/build-inventory.ts
@@ -1,44 +1,54 @@
 import {
+  GovernanceDependencyInput,
+  GovernanceProjectInput,
+  GovernanceWorkspaceAdapterResult,
   GovernanceDependency,
   GovernanceProject,
   GovernanceWorkspace,
   Ownership,
   ProfileOverrides,
 } from '../core/index.js';
-import { AdapterWorkspaceSnapshot } from '../nx-adapter/types.js';
 
-// TODO(#248): Switch inventory normalization to the Core-owned
-// GovernanceWorkspaceAdapterResult contract without changing behavior.
 export function buildInventory(
-  snapshot: AdapterWorkspaceSnapshot,
+  adapterResult: GovernanceWorkspaceAdapterResult,
   overrides: ProfileOverrides = { projectOverrides: {} }
 ): GovernanceWorkspace {
-  const projects: GovernanceProject[] = snapshot.projects.map((project) => {
-    const override = overrides.projectOverrides[project.name] ?? {};
-    const domain =
-      override.domain ?? tagValue(project.tags, 'domain') ?? tagValue(project.tags, 'scope');
-    const layer = override.layer ?? tagValue(project.tags, 'layer');
+  const projectsInput = resolveProjects(adapterResult);
+  const dependenciesInput = resolveDependencies(adapterResult);
 
-    const ownershipFromMeta = readOwnershipFromMetadata(project.metadata);
-    const codeowners = snapshot.codeownersByProject[project.name] ?? [];
+  const projects: GovernanceProject[] = projectsInput.map((project) => {
+    const projectId = normalizeProjectId(project);
+    const projectName = normalizeProjectName(project);
+    const projectTags = project.tags ?? [];
+    const projectMetadata = project.metadata ?? {};
+    const override = overrides.projectOverrides[projectName] ?? {};
+    const domain =
+      override.domain ??
+      project.domain ??
+      tagValue(projectTags, 'domain') ??
+      tagValue(projectTags, 'scope');
+    const layer =
+      override.layer ?? project.layer ?? tagValue(projectTags, 'layer');
+
+    const ownershipFromMeta = readOwnershipFromMetadata(projectMetadata);
 
     const ownership: Ownership = resolveOwnership(
       ownershipFromMeta,
       override.ownershipTeam,
-      codeowners
+      project.ownership
     );
 
     return {
-      id: project.name,
-      name: project.name,
-      root: project.root,
+      id: projectId,
+      name: projectName,
+      root: project.root ?? '',
       type: normalizeProjectType(project.type),
-      tags: project.tags,
+      tags: projectTags,
       domain,
       layer,
       ownership,
       metadata: {
-        ...project.metadata,
+        ...projectMetadata,
         ...(override.documentation !== undefined
           ? { documentation: override.documentation }
           : {}),
@@ -46,20 +56,74 @@ export function buildInventory(
     };
   });
 
-  const dependencies: GovernanceDependency[] = snapshot.dependencies.map((dep) => ({
-    source: dep.source,
-    target: dep.target,
+  const dependencies: GovernanceDependency[] = dependenciesInput.map((dep) => ({
+    source: dep.sourceProjectId,
+    target: dep.targetProjectId,
     type: normalizeDependencyType(dep.type),
     sourceFile: dep.sourceFile,
   }));
 
   return {
-    id: 'workspace',
-    name: 'workspace',
-    root: snapshot.root,
+    id: adapterResult.workspaceId ?? adapterResult.workspace?.id ?? 'workspace',
+    name:
+      adapterResult.workspaceName ??
+      adapterResult.workspace?.name ??
+      'workspace',
+    root: adapterResult.workspaceRoot ?? adapterResult.workspace?.root ?? '',
     projects,
     dependencies,
   };
+}
+
+function resolveProjects(
+  adapterResult: GovernanceWorkspaceAdapterResult
+): GovernanceProjectInput[] {
+  if (adapterResult.projects) {
+    return adapterResult.projects;
+  }
+
+  if (adapterResult.workspace) {
+    return adapterResult.workspace.projects.map((project) => ({
+      id: project.id,
+      name: project.name,
+      root: project.root,
+      type: project.type,
+      domain: project.domain,
+      layer: project.layer,
+      tags: project.tags,
+      ownership: project.ownership,
+      metadata: project.metadata,
+    }));
+  }
+
+  return [];
+}
+
+function resolveDependencies(
+  adapterResult: GovernanceWorkspaceAdapterResult
+): GovernanceDependencyInput[] {
+  if (adapterResult.dependencies) {
+    return adapterResult.dependencies;
+  }
+
+  if (adapterResult.workspace) {
+    return adapterResult.workspace.dependencies.map((dependency) => ({
+      sourceProjectId: dependency.source,
+      targetProjectId: dependency.target,
+      type: dependency.type,
+      sourceFile: dependency.sourceFile,
+    }));
+  }
+
+  return [];
+}
+
+function normalizeProjectId(project: GovernanceProjectInput): string {
+  return project.id;
+}
+
+function normalizeProjectName(project: GovernanceProjectInput): string {
+  return project.name ?? project.id;
 }
 
 function tagValue(tags: string[], prefix: string): string | undefined {
@@ -68,7 +132,7 @@ function tagValue(tags: string[], prefix: string): string | undefined {
 }
 
 function normalizeProjectType(
-  type: string
+  type: string | undefined
 ): 'application' | 'library' | 'tool' | 'unknown' {
   if (type === 'application' || type === 'app') return 'application';
   if (type === 'library' || type === 'lib') return 'library';
@@ -77,7 +141,7 @@ function normalizeProjectType(
 }
 
 function normalizeDependencyType(
-  type: string
+  type: string | undefined
 ): 'static' | 'dynamic' | 'implicit' | 'unknown' {
   if (type === 'static' || type === 'dynamic' || type === 'implicit') {
     return type;
@@ -106,14 +170,21 @@ function readOwnershipFromMetadata(
 function resolveOwnership(
   metadataTeam: string | undefined,
   overrideTeam: string | undefined,
-  codeowners: string[]
+  adapterOwnership:
+    | {
+        team?: string;
+        contacts?: string[];
+        source?: string;
+      }
+    | undefined
 ): Ownership {
-  const team = overrideTeam ?? metadataTeam;
+  const contacts = adapterOwnership?.contacts ?? [];
+  const team = overrideTeam ?? metadataTeam ?? adapterOwnership?.team;
 
-  if (team && codeowners.length) {
+  if (team && contacts.length) {
     return {
       team,
-      contacts: codeowners,
+      contacts,
       source: 'merged',
     };
   }
@@ -122,13 +193,13 @@ function resolveOwnership(
     return {
       team,
       contacts: [],
-      source: 'project-metadata',
+      source: normalizeOwnershipSource(adapterOwnership?.source),
     };
   }
 
-  if (codeowners.length) {
+  if (contacts.length) {
     return {
-      contacts: codeowners,
+      contacts,
       source: 'codeowners',
     };
   }
@@ -136,4 +207,18 @@ function resolveOwnership(
   return {
     source: 'none',
   };
+}
+
+function normalizeOwnershipSource(
+  source: string | undefined
+): Ownership['source'] {
+  if (source === 'merged' || source === 'project-metadata') {
+    return source;
+  }
+
+  if (source === 'codeowners') {
+    return 'codeowners';
+  }
+
+  return 'project-metadata';
 }

--- a/packages/governance/src/metric-engine/workspace-fixtures.spec.ts
+++ b/packages/governance/src/metric-engine/workspace-fixtures.spec.ts
@@ -1,6 +1,7 @@
 import { calculateHealthScore } from '../health-engine/calculate-health.js';
 import { buildInventory } from '../inventory/build-inventory.js';
 import type { AdapterWorkspaceSnapshot } from '../nx-adapter/types.js';
+import { toGovernanceWorkspaceAdapterResult } from '../nx-adapter/to-governance-workspace-adapter-result.js';
 import { evaluatePolicies } from '../policy-engine/evaluate-policies.js';
 import { frontendLayeredProfile } from '../presets/frontend-layered/profile.js';
 import {
@@ -149,7 +150,12 @@ describe('workspace metric baselines', () => {
   it.each(WORKSPACE_FIXTURES)(
     'matches expected weighted metric baseline for $name',
     ({ snapshot, expected }) => {
-      const inventory = buildInventory(snapshot, { projectOverrides: {} });
+      const inventory = buildInventory(
+        toGovernanceWorkspaceAdapterResult(snapshot),
+        {
+          projectOverrides: {},
+        }
+      );
       const violations = evaluatePolicies(inventory, frontendLayeredProfile);
       const signals = [
         ...buildGraphSignals(toWorkspaceGraphSnapshot(inventory)),

--- a/packages/governance/src/nx-adapter/to-governance-workspace-adapter-result.ts
+++ b/packages/governance/src/nx-adapter/to-governance-workspace-adapter-result.ts
@@ -1,0 +1,45 @@
+import type {
+  GovernanceProjectInput,
+  GovernanceWorkspaceAdapterResult,
+} from '../core/index.js';
+
+import type { AdapterWorkspaceSnapshot } from './types.js';
+
+export function toGovernanceWorkspaceAdapterResult(
+  snapshot: AdapterWorkspaceSnapshot
+): GovernanceWorkspaceAdapterResult {
+  return {
+    workspaceRoot: snapshot.root,
+    projects: snapshot.projects.map((project) => ({
+      id: project.name,
+      name: project.name,
+      root: project.root,
+      type: project.type,
+      tags: project.tags,
+      metadata: project.metadata,
+      ownership: projectOwnershipFromSnapshot(project, snapshot),
+    })),
+    dependencies: snapshot.dependencies.map((dependency) => ({
+      sourceProjectId: dependency.source,
+      targetProjectId: dependency.target,
+      type: dependency.type,
+      sourceFile: dependency.sourceFile,
+    })),
+  };
+}
+
+function projectOwnershipFromSnapshot(
+  project: AdapterWorkspaceSnapshot['projects'][number],
+  snapshot: AdapterWorkspaceSnapshot
+): GovernanceProjectInput['ownership'] {
+  const contacts = snapshot.codeownersByProject[project.name] ?? [];
+
+  if (contacts.length === 0) {
+    return undefined;
+  }
+
+  return {
+    contacts,
+    source: 'codeowners',
+  };
+}

--- a/packages/governance/src/plugin/run-governance.ts
+++ b/packages/governance/src/plugin/run-governance.ts
@@ -8,6 +8,7 @@ import {
 import { buildInventory } from '../inventory/build-inventory.js';
 import { calculateMetrics } from '../metric-engine/calculate-metrics.js';
 import { readNxWorkspaceSnapshot } from '../nx-adapter/read-workspace.js';
+import { toGovernanceWorkspaceAdapterResult } from '../nx-adapter/to-governance-workspace-adapter-result.js';
 import { evaluatePolicies } from '../policy-engine/evaluate-policies.js';
 import {
   loadProfileOverrides,
@@ -1504,7 +1505,10 @@ async function buildAssessmentArtifacts(
   };
 
   const snapshot = await readNxWorkspaceSnapshot();
-  const inventory = buildInventory(snapshot, overrides);
+  const inventory = buildInventory(
+    toGovernanceWorkspaceAdapterResult(snapshot),
+    overrides
+  );
   const extensionRegistry = await registerGovernanceExtensions({
     workspaceRoot,
     profileName,


### PR DESCRIPTION
closes #248