### PR TITLE
refactor(nx-governance): Isolate the Nx adapter behind the Core adapter boundary by making the adapter expose Core-owned adapter result data for the inventory/governance flow, while keeping Nx graph loading inside .

### DIFF
--- a/packages/governance/src/metric-engine/workspace-fixtures.spec.ts
+++ b/packages/governance/src/metric-engine/workspace-fixtures.spec.ts
@@ -1,19 +1,18 @@
 import { calculateHealthScore } from '../health-engine/calculate-health.js';
 import { buildInventory } from '../inventory/build-inventory.js';
-import type { AdapterWorkspaceSnapshot } from '../nx-adapter/types.js';
-import { toGovernanceWorkspaceAdapterResult } from '../nx-adapter/to-governance-workspace-adapter-result.js';
 import { evaluatePolicies } from '../policy-engine/evaluate-policies.js';
 import { frontendLayeredProfile } from '../presets/frontend-layered/profile.js';
 import {
   buildGraphSignals,
   buildPolicySignals,
 } from '../signal-engine/index.js';
+import type { GovernanceWorkspaceAdapterResult } from '../core/index.js';
 
 import { calculateMetrics } from './calculate-metrics.js';
 
 const WORKSPACE_FIXTURES: Array<{
   name: string;
-  snapshot: AdapterWorkspaceSnapshot;
+  adapterResult: GovernanceWorkspaceAdapterResult;
   expected: {
     violationRuleIds: string[];
     measurements: Record<string, { value: number; score: number }>;
@@ -27,8 +26,8 @@ const WORKSPACE_FIXTURES: Array<{
 }> = [
   {
     name: 'healthy layered workspace',
-    snapshot: {
-      root: '/workspace',
+    adapterResult: {
+      workspaceRoot: '/workspace',
       projects: [
         project('shop-app', 'application', 'shop', 'app', true, true),
         project('shop-feature', 'library', 'shop', 'feature', true, true),
@@ -40,7 +39,6 @@ const WORKSPACE_FIXTURES: Array<{
         dependency('shop-feature', 'shop-ui'),
         dependency('shop-ui', 'shop-util'),
       ],
-      codeownersByProject: {},
     },
     expected: {
       violationRuleIds: [],
@@ -62,8 +60,8 @@ const WORKSPACE_FIXTURES: Array<{
   },
   {
     name: 'shared dependency warning workspace',
-    snapshot: {
-      root: '/workspace',
+    adapterResult: {
+      workspaceRoot: '/workspace',
       projects: [
         project('shop-app', 'application', 'shop', 'app', true, true),
         project('shop-feature', 'library', 'shop', 'feature', true, true),
@@ -75,7 +73,6 @@ const WORKSPACE_FIXTURES: Array<{
         dependency('shop-feature', 'shared-ui'),
         dependency('shared-ui', 'shared-util'),
       ],
-      codeownersByProject: {},
     },
     expected: {
       violationRuleIds: [],
@@ -97,8 +94,8 @@ const WORKSPACE_FIXTURES: Array<{
   },
   {
     name: 'boundary and ownership hotspot workspace',
-    snapshot: {
-      root: '/workspace',
+    adapterResult: {
+      workspaceRoot: '/workspace',
       projects: [
         project('orders-app', 'application', 'orders', 'app', true, true),
         project(
@@ -115,7 +112,6 @@ const WORKSPACE_FIXTURES: Array<{
         dependency('orders-app', 'payments-feature'),
         dependency('payments-ui', 'orders-app'),
       ],
-      codeownersByProject: {},
     },
     expected: {
       violationRuleIds: [
@@ -149,13 +145,10 @@ const WORKSPACE_FIXTURES: Array<{
 describe('workspace metric baselines', () => {
   it.each(WORKSPACE_FIXTURES)(
     'matches expected weighted metric baseline for $name',
-    ({ snapshot, expected }) => {
-      const inventory = buildInventory(
-        toGovernanceWorkspaceAdapterResult(snapshot),
-        {
-          projectOverrides: {},
-        }
-      );
+    ({ adapterResult, expected }) => {
+      const inventory = buildInventory(adapterResult, {
+        projectOverrides: {},
+      });
       const violations = evaluatePolicies(inventory, frontendLayeredProfile);
       const signals = [
         ...buildGraphSignals(toWorkspaceGraphSnapshot(inventory)),
@@ -237,6 +230,7 @@ function project(
   documented: boolean
 ) {
   return {
+    id: name,
     name,
     root: `packages/${name}`,
     type,
@@ -256,8 +250,8 @@ function project(
 
 function dependency(source: string, target: string) {
   return {
-    source,
-    target,
+    sourceProjectId: source,
+    targetProjectId: target,
     type: 'static' as const,
   };
 }

--- a/packages/governance/src/nx-adapter/read-workspace.ts
+++ b/packages/governance/src/nx-adapter/read-workspace.ts
@@ -2,8 +2,11 @@ import { createProjectGraphAsync, workspaceRoot } from '@nx/devkit';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+import type { GovernanceWorkspaceAdapterResult } from '../core/index.js';
+
 import { ownersForProjectRoot, readCodeowners } from './codeowners.js';
-import { AdapterWorkspaceSnapshot } from './types.js';
+import { toGovernanceWorkspaceAdapterResult } from './to-governance-workspace-adapter-result.js';
+import type { AdapterWorkspaceSnapshot } from './types.js';
 
 export async function readNxWorkspaceSnapshot(): Promise<AdapterWorkspaceSnapshot> {
   const graph = await createProjectGraphAsync();
@@ -64,6 +67,16 @@ export async function readNxWorkspaceSnapshot(): Promise<AdapterWorkspaceSnapsho
     dependencies,
     codeownersByProject,
   };
+}
+
+export function createNxWorkspaceAdapterResult(
+  snapshot: AdapterWorkspaceSnapshot
+): GovernanceWorkspaceAdapterResult {
+  return toGovernanceWorkspaceAdapterResult(snapshot);
+}
+
+export async function readNxWorkspaceAdapterResult(): Promise<GovernanceWorkspaceAdapterResult> {
+  return createNxWorkspaceAdapterResult(await readNxWorkspaceSnapshot());
 }
 
 export function resolveProjectTagsAndMetadata(

--- a/packages/governance/src/nx-adapter/to-governance-workspace-adapter-result.spec.ts
+++ b/packages/governance/src/nx-adapter/to-governance-workspace-adapter-result.spec.ts
@@ -1,0 +1,94 @@
+import type { AdapterWorkspaceSnapshot } from './types.js';
+import { toGovernanceWorkspaceAdapterResult } from './to-governance-workspace-adapter-result.js';
+
+describe('toGovernanceWorkspaceAdapterResult', () => {
+  it('maps nx snapshot data into the core-owned adapter result shape', () => {
+    const snapshot: AdapterWorkspaceSnapshot = {
+      root: '/workspace',
+      projects: [
+        {
+          name: 'booking-ui',
+          root: 'libs/booking/ui',
+          type: 'library',
+          tags: ['scope:booking', 'layer:ui', 'type:ui'],
+          metadata: {
+            documentation: true,
+          },
+        },
+        {
+          name: 'booking-domain',
+          root: 'libs/booking/domain',
+          type: 'library',
+          tags: ['scope:booking', 'layer:domain', 'type:domain'],
+          metadata: {
+            ownership: {
+              team: 'booking-team',
+            },
+          },
+        },
+      ],
+      dependencies: [
+        {
+          source: 'booking-ui',
+          target: 'booking-domain',
+          type: 'static',
+          sourceFile: 'libs/booking/ui/src/lib/ui.ts',
+        },
+      ],
+      codeownersByProject: {
+        'booking-domain': ['@booking-team'],
+      },
+    };
+
+    expect(toGovernanceWorkspaceAdapterResult(snapshot)).toEqual({
+      workspaceRoot: '/workspace',
+      projects: [
+        {
+          id: 'booking-ui',
+          name: 'booking-ui',
+          root: 'libs/booking/ui',
+          type: 'library',
+          tags: ['scope:booking', 'layer:ui', 'type:ui'],
+          metadata: {
+            documentation: true,
+          },
+        },
+        {
+          id: 'booking-domain',
+          name: 'booking-domain',
+          root: 'libs/booking/domain',
+          type: 'library',
+          tags: ['scope:booking', 'layer:domain', 'type:domain'],
+          metadata: {
+            ownership: {
+              team: 'booking-team',
+            },
+          },
+          ownership: {
+            contacts: ['@booking-team'],
+            source: 'codeowners',
+          },
+        },
+      ],
+      dependencies: [
+        {
+          sourceProjectId: 'booking-ui',
+          targetProjectId: 'booking-domain',
+          type: 'static',
+          sourceFile: 'libs/booking/ui/src/lib/ui.ts',
+        },
+      ],
+      capabilities: [
+        {
+          id: 'capability:nx',
+          data: {
+            projectGraphAvailable: true,
+            tagsAvailable: true,
+            metadataAvailable: true,
+            source: 'nx-project-graph',
+          },
+        },
+      ],
+    });
+  });
+});

--- a/packages/governance/src/nx-adapter/to-governance-workspace-adapter-result.ts
+++ b/packages/governance/src/nx-adapter/to-governance-workspace-adapter-result.ts
@@ -25,6 +25,17 @@ export function toGovernanceWorkspaceAdapterResult(
       type: dependency.type,
       sourceFile: dependency.sourceFile,
     })),
+    capabilities: [
+      {
+        id: 'capability:nx',
+        data: {
+          projectGraphAvailable: true,
+          tagsAvailable: true,
+          metadataAvailable: true,
+          source: 'nx-project-graph',
+        },
+      },
+    ],
   };
 }
 

--- a/packages/governance/src/plugin/run-governance.ts
+++ b/packages/governance/src/plugin/run-governance.ts
@@ -7,8 +7,10 @@ import {
 } from '../health-engine/calculate-health.js';
 import { buildInventory } from '../inventory/build-inventory.js';
 import { calculateMetrics } from '../metric-engine/calculate-metrics.js';
-import { readNxWorkspaceSnapshot } from '../nx-adapter/read-workspace.js';
-import { toGovernanceWorkspaceAdapterResult } from '../nx-adapter/to-governance-workspace-adapter-result.js';
+import {
+  createNxWorkspaceAdapterResult,
+  readNxWorkspaceSnapshot,
+} from '../nx-adapter/read-workspace.js';
 import { evaluatePolicies } from '../policy-engine/evaluate-policies.js';
 import {
   loadProfileOverrides,
@@ -1506,7 +1508,7 @@ async function buildAssessmentArtifacts(
 
   const snapshot = await readNxWorkspaceSnapshot();
   const inventory = buildInventory(
-    toGovernanceWorkspaceAdapterResult(snapshot),
+    createNxWorkspaceAdapterResult(snapshot),
     overrides
   );
   const extensionRegistry = await registerGovernanceExtensions({


### PR DESCRIPTION
close #249