### PR TITLE
refactor(nx-governance): Move the existing domain boundary, layer boundary, and ownership-presence policies behind Core-owned rule definitions and the Core built-in rule pack structure.

### DIFF
--- a/packages/governance/src/core/built-in-rule-pack.ts
+++ b/packages/governance/src/core/built-in-rule-pack.ts
@@ -1,12 +1,12 @@
+import { coreBuiltInPolicyRules } from './built-in-rules.js';
 import type { GovernanceRulePack } from './rules.js';
 
 export const CORE_BUILT_IN_RULE_PACK_ID = 'core';
 
-// #244 will migrate the current built-in policy behavior behind this pack.
 export const coreBuiltInRulePack: GovernanceRulePack = {
   id: CORE_BUILT_IN_RULE_PACK_ID,
   name: 'Governance Core Built-in Rules',
-  rules: [],
+  rules: coreBuiltInPolicyRules,
 };
 
 export const coreBuiltInRulePacks: GovernanceRulePack[] = [coreBuiltInRulePack];

--- a/packages/governance/src/core/built-in-rules.spec.ts
+++ b/packages/governance/src/core/built-in-rules.spec.ts
@@ -1,0 +1,257 @@
+import {
+  coreBuiltInRulePack,
+  domainBoundaryRule,
+  evaluateRulePack,
+  layerBoundaryRule,
+  ownershipPresenceRule,
+  type GovernanceProfile,
+  type GovernanceWorkspace,
+} from './index.js';
+
+describe('Core built-in policy rules', () => {
+  const baseProfile: GovernanceProfile = {
+    name: 'test-profile',
+    boundaryPolicySource: 'profile',
+    layers: ['app', 'feature', 'ui', 'data-access', 'util'],
+    allowedDomainDependencies: {
+      '*': [],
+    },
+    ownership: {
+      required: true,
+      metadataField: 'ownership',
+    },
+    health: {
+      statusThresholds: {
+        goodMinScore: 85,
+        warningMinScore: 70,
+      },
+    },
+    metrics: {} as GovernanceProfile['metrics'],
+  };
+
+  const baseWorkspace: GovernanceWorkspace = {
+    id: 'workspace',
+    name: 'workspace',
+    root: '.',
+    projects: [
+      {
+        id: 'booking-feature',
+        name: 'booking-feature',
+        root: 'libs/booking/feature',
+        type: 'library',
+        tags: ['domain:booking', 'layer:feature'],
+        domain: 'booking',
+        layer: 'feature',
+        ownership: {
+          team: 'booking-team',
+          source: 'project-metadata',
+        },
+        metadata: {},
+      },
+      {
+        id: 'payments-ui',
+        name: 'payments-ui',
+        root: 'libs/payments/ui',
+        type: 'library',
+        tags: ['domain:payments', 'layer:ui'],
+        domain: 'payments',
+        layer: 'ui',
+        ownership: {
+          team: 'payments-team',
+          source: 'project-metadata',
+        },
+        metadata: {},
+      },
+      {
+        id: 'shared-data',
+        name: 'shared-data',
+        root: 'libs/shared/data',
+        type: 'library',
+        tags: ['domain:shared', 'layer:data-access'],
+        domain: 'shared',
+        layer: 'data-access',
+        ownership: {
+          team: 'shared-team',
+          source: 'project-metadata',
+        },
+        metadata: {},
+      },
+    ],
+    dependencies: [
+      {
+        source: 'booking-feature',
+        target: 'payments-ui',
+        type: 'static',
+      },
+    ],
+  };
+
+  it('does not report a domain violation for allowed domain dependencies', () => {
+    const result = domainBoundaryRule.evaluate({
+      workspace: baseWorkspace,
+      profile: {
+        ...baseProfile,
+        allowedDomainDependencies: {
+          booking: ['payments'],
+        },
+      },
+    });
+
+    expect(result.violations ?? []).toEqual([]);
+  });
+
+  it('reports a domain violation for disallowed domain dependencies', () => {
+    const result = domainBoundaryRule.evaluate({
+      workspace: baseWorkspace,
+      profile: baseProfile,
+    });
+
+    expect(result.violations).toEqual([
+      expect.objectContaining({
+        ruleId: 'domain-boundary',
+        project: 'booking-feature',
+        severity: 'error',
+        category: 'boundary',
+        details: {
+          targetProject: 'payments-ui',
+          sourceDomain: 'booking',
+          targetDomain: 'payments',
+          dependencyType: 'static',
+        },
+      }),
+    ]);
+  });
+
+  it('does not report a layer violation for allowed layer dependencies', () => {
+    const result = layerBoundaryRule.evaluate({
+      workspace: baseWorkspace,
+      profile: {
+        ...baseProfile,
+        allowedDomainDependencies: {
+          booking: ['payments'],
+        },
+      },
+    });
+
+    expect(result.violations ?? []).toEqual([]);
+  });
+
+  it('reports a layer violation for disallowed layer dependencies', () => {
+    const result = layerBoundaryRule.evaluate({
+      workspace: {
+        ...baseWorkspace,
+        dependencies: [
+          {
+            source: 'shared-data',
+            target: 'booking-feature',
+            type: 'static',
+          },
+        ],
+      },
+      profile: {
+        ...baseProfile,
+        allowedDomainDependencies: {
+          shared: ['booking'],
+        },
+      },
+    });
+
+    expect(result.violations).toEqual([
+      expect.objectContaining({
+        ruleId: 'layer-boundary',
+        project: 'shared-data',
+        severity: 'warning',
+        category: 'boundary',
+        details: {
+          targetProject: 'booking-feature',
+          sourceLayer: 'data-access',
+          targetLayer: 'feature',
+          order: ['app', 'feature', 'ui', 'data-access', 'util'],
+        },
+      }),
+    ]);
+  });
+
+  it('reports an ownership violation when ownership is missing', () => {
+    const result = ownershipPresenceRule.evaluate({
+      workspace: {
+        ...baseWorkspace,
+        projects: [
+          {
+            ...baseWorkspace.projects[0],
+            ownership: {
+              source: 'none',
+            },
+          },
+        ],
+        dependencies: [],
+      },
+      profile: baseProfile,
+    });
+
+    expect(result.violations).toEqual([
+      expect.objectContaining({
+        ruleId: 'ownership-presence',
+        project: 'booking-feature',
+        severity: 'warning',
+        category: 'ownership',
+      }),
+    ]);
+  });
+
+  it('does not report an ownership violation when ownership is present', () => {
+    const result = ownershipPresenceRule.evaluate({
+      workspace: {
+        ...baseWorkspace,
+        dependencies: [],
+      },
+      profile: baseProfile,
+    });
+
+    expect(result.violations ?? []).toEqual([]);
+  });
+
+  it('registers the migrated rules in the built-in core rule pack', () => {
+    expect(coreBuiltInRulePack.rules.map((rule) => rule.id)).toEqual([
+      'domain-boundary',
+      'layer-boundary',
+      'ownership-presence',
+    ]);
+  });
+
+  it('executes the migrated rules through the built-in core rule pack', async () => {
+    const result = await evaluateRulePack(coreBuiltInRulePack, {
+      workspace: {
+        ...baseWorkspace,
+        projects: [
+          {
+            ...baseWorkspace.projects[0],
+            ownership: {
+              source: 'none',
+            },
+          },
+          ...baseWorkspace.projects.slice(1),
+        ],
+        dependencies: [
+          {
+            source: 'shared-data',
+            target: 'booking-feature',
+            type: 'static',
+          },
+        ],
+      },
+      profile: {
+        ...baseProfile,
+        allowedDomainDependencies: {
+          '*': [],
+        },
+      },
+    });
+
+    expect(result.violations.map((violation) => violation.ruleId)).toEqual([
+      'domain-boundary',
+      'layer-boundary',
+      'ownership-presence',
+    ]);
+  });
+});

--- a/packages/governance/src/core/built-in-rules.ts
+++ b/packages/governance/src/core/built-in-rules.ts
@@ -1,0 +1,293 @@
+import type { GovernanceProject, Violation } from './models.js';
+import {
+  deriveAllowedLayerDependenciesFromLayerOrder,
+  type GovernanceProfile,
+} from './profile.js';
+import type { GovernanceRule, GovernanceRuleContext } from './rules.js';
+
+export const domainBoundaryRule: GovernanceRule = {
+  id: 'domain-boundary',
+  name: 'Domain Boundary',
+  description:
+    'Enforces allowed dependencies between projects in different domains.',
+  category: 'boundary',
+  defaultSeverity: 'error',
+  evaluate({ workspace, profile }) {
+    if (!profile) {
+      return {};
+    }
+
+    const projectByName = projectByNameMap(workspace.projects);
+    const violations = workspace.dependencies.flatMap((dependency) => {
+      const source = projectByName.get(dependency.source);
+      const target = projectByName.get(dependency.target);
+
+      return evaluateDomainBoundaryDependency(
+        source,
+        target,
+        dependency,
+        profile
+      );
+    });
+
+    return { violations };
+  },
+};
+
+export const layerBoundaryRule: GovernanceRule = {
+  id: 'layer-boundary',
+  name: 'Layer Boundary',
+  description:
+    'Enforces allowed dependencies between declared architectural layers.',
+  category: 'boundary',
+  defaultSeverity: 'warning',
+  evaluate({ workspace, profile }) {
+    if (!profile) {
+      return {};
+    }
+
+    const projectByName = projectByNameMap(workspace.projects);
+    const declaredLayers = new Set(profile.layers);
+    const usesExplicitLayerDependencies =
+      profile.allowedLayerDependencies !== undefined;
+    const allowedLayerDependencies =
+      profile.allowedLayerDependencies ??
+      deriveAllowedLayerDependenciesFromLayerOrder(profile.layers);
+
+    const violations = workspace.dependencies.flatMap((dependency) => {
+      const source = projectByName.get(dependency.source);
+      const target = projectByName.get(dependency.target);
+
+      return evaluateLayerBoundaryDependency(
+        source,
+        target,
+        dependency,
+        declaredLayers,
+        usesExplicitLayerDependencies,
+        allowedLayerDependencies,
+        profile
+      );
+    });
+
+    return { violations };
+  },
+};
+
+export const ownershipPresenceRule: GovernanceRule = {
+  id: 'ownership-presence',
+  name: 'Ownership Presence',
+  description:
+    'Requires ownership metadata or CODEOWNERS coverage when profiles demand it.',
+  category: 'ownership',
+  defaultSeverity: 'warning',
+  evaluate({ workspace, profile }) {
+    if (!profile?.ownership.required) {
+      return {};
+    }
+
+    const violations = workspace.projects.flatMap((project) =>
+      evaluateOwnershipPresence(project)
+    );
+
+    return { violations };
+  },
+};
+
+export const coreBuiltInPolicyRules: GovernanceRule[] = [
+  domainBoundaryRule,
+  layerBoundaryRule,
+  ownershipPresenceRule,
+];
+
+export function evaluateCoreBuiltInPolicyViolations(
+  context: GovernanceRuleContext
+): Violation[] {
+  if (!context.profile) {
+    return [];
+  }
+
+  const { workspace, profile } = context;
+  const projectByName = projectByNameMap(workspace.projects);
+  const declaredLayers = new Set(profile.layers);
+  const usesExplicitLayerDependencies =
+    profile.allowedLayerDependencies !== undefined;
+  const allowedLayerDependencies =
+    profile.allowedLayerDependencies ??
+    deriveAllowedLayerDependenciesFromLayerOrder(profile.layers);
+  const violations: Violation[] = [];
+
+  for (const dependency of workspace.dependencies) {
+    const source = projectByName.get(dependency.source);
+    const target = projectByName.get(dependency.target);
+
+    violations.push(
+      ...evaluateDomainBoundaryDependency(source, target, dependency, profile)
+    );
+    violations.push(
+      ...evaluateLayerBoundaryDependency(
+        source,
+        target,
+        dependency,
+        declaredLayers,
+        usesExplicitLayerDependencies,
+        allowedLayerDependencies,
+        profile
+      )
+    );
+  }
+
+  if (profile.ownership.required) {
+    for (const project of workspace.projects) {
+      violations.push(...evaluateOwnershipPresence(project));
+    }
+  }
+
+  return violations;
+}
+
+function evaluateDomainBoundaryDependency(
+  source: GovernanceProject | undefined,
+  target: GovernanceProject | undefined,
+  dependency: GovernanceRuleContext['workspace']['dependencies'][number],
+  profile: GovernanceProfile
+): Violation[] {
+  if (!source || !target) {
+    return [];
+  }
+
+  if (
+    !source.domain ||
+    !target.domain ||
+    source.domain === target.domain ||
+    isDomainDependencyAllowed(profile, source.domain, target.domain)
+  ) {
+    return [];
+  }
+
+  return [
+    {
+      id: `${source.name}-${target.name}-domain`,
+      ruleId: 'domain-boundary',
+      project: source.name,
+      severity: 'error',
+      category: 'boundary',
+      message: `Project ${source.name} in domain ${source.domain} depends on ${target.name} in domain ${target.domain}.`,
+      details: {
+        targetProject: target.name,
+        sourceDomain: source.domain,
+        targetDomain: target.domain,
+        dependencyType: dependency.type,
+      },
+      recommendation:
+        'Move the dependency behind an API or adjust domain boundaries in the governance profile.',
+    },
+  ];
+}
+
+function evaluateLayerBoundaryDependency(
+  source: GovernanceProject | undefined,
+  target: GovernanceProject | undefined,
+  _dependency: GovernanceRuleContext['workspace']['dependencies'][number],
+  declaredLayers: Set<string>,
+  usesExplicitLayerDependencies: boolean,
+  allowedLayerDependencies: Record<string, string[]>,
+  profile: GovernanceProfile
+): Violation[] {
+  if (!source || !target) {
+    return [];
+  }
+
+  if (
+    !source.layer ||
+    !target.layer ||
+    !declaredLayers.has(source.layer) ||
+    !declaredLayers.has(target.layer) ||
+    isLayerDependencyAllowed(
+      allowedLayerDependencies,
+      source.layer,
+      target.layer
+    )
+  ) {
+    return [];
+  }
+
+  return [
+    {
+      id: `${source.name}-${target.name}-layer`,
+      ruleId: 'layer-boundary',
+      project: source.name,
+      severity: 'warning',
+      category: 'boundary',
+      message: `Layer violation: ${source.name} (${source.layer}) depends on ${target.name} (${target.layer}).`,
+      details: {
+        targetProject: target.name,
+        sourceLayer: source.layer,
+        targetLayer: target.layer,
+        ...(usesExplicitLayerDependencies
+          ? {
+              allowedTargets: allowedLayerDependencies[source.layer] ?? [],
+            }
+          : {
+              order: profile.layers,
+            }),
+      },
+      recommendation: usesExplicitLayerDependencies
+        ? 'Refactor the dependency or update allowedLayerDependencies in the governance profile when the dependency is intentional.'
+        : 'Refactor dependency direction so higher-level layers depend on same or lower-level layers only.',
+    },
+  ];
+}
+
+function evaluateOwnershipPresence(project: GovernanceProject): Violation[] {
+  if (
+    project.ownership?.team ||
+    (project.ownership?.contacts?.length ?? 0) > 0
+  ) {
+    return [];
+  }
+
+  return [
+    {
+      id: `${project.name}-ownership`,
+      ruleId: 'ownership-presence',
+      project: project.name,
+      severity: 'warning',
+      category: 'ownership',
+      message: `Project ${project.name} has no ownership metadata or CODEOWNERS mapping.`,
+      recommendation:
+        'Add ownership metadata in project configuration or ensure CODEOWNERS covers the project root.',
+    },
+  ];
+}
+
+function projectByNameMap(
+  projects: GovernanceProject[]
+): Map<string, GovernanceProject> {
+  return new Map(projects.map((project) => [project.name, project]));
+}
+
+function isDomainDependencyAllowed(
+  profile: GovernanceProfile,
+  sourceDomain: string,
+  targetDomain: string
+): boolean {
+  const direct = profile.allowedDomainDependencies[sourceDomain];
+  if (direct && (direct.includes(targetDomain) || direct.includes('*'))) {
+    return true;
+  }
+
+  const wildcard = profile.allowedDomainDependencies['*'];
+  if (wildcard && (wildcard.includes(targetDomain) || wildcard.includes('*'))) {
+    return true;
+  }
+
+  return false;
+}
+
+function isLayerDependencyAllowed(
+  allowedLayerDependencies: Record<string, string[]>,
+  sourceLayer: string,
+  targetLayer: string
+): boolean {
+  return (allowedLayerDependencies[sourceLayer] ?? []).includes(targetLayer);
+}

--- a/packages/governance/src/core/index.ts
+++ b/packages/governance/src/core/index.ts
@@ -1,5 +1,6 @@
 export * from './adapter.js';
 export * from './built-in-rule-pack.js';
+export * from './built-in-rules.js';
 export * from './models.js';
 export * from './exceptions.js';
 export * from './profile.js';

--- a/packages/governance/src/core/rule-engine.spec.ts
+++ b/packages/governance/src/core/rule-engine.spec.ts
@@ -2,6 +2,7 @@ import type {
   GovernanceRule,
   GovernanceRuleCategory,
   GovernanceRuleContext,
+  GovernanceRulePack,
   GovernanceRuleSeverity,
   GovernanceSignal,
   Measurement,
@@ -18,8 +19,14 @@ import { coreTestWorkspace } from './testing/workspace.fixtures.js';
 
 describe('Core rule engine contracts', () => {
   it('returns empty arrays for an empty rule pack', async () => {
+    const emptyRulePack: GovernanceRulePack = {
+      id: 'empty',
+      name: 'Empty',
+      rules: [],
+    };
+
     await expect(
-      evaluateRulePack(coreBuiltInRulePack, {
+      evaluateRulePack(emptyRulePack, {
         workspace: coreTestWorkspace,
       })
     ).resolves.toEqual({
@@ -171,11 +178,13 @@ describe('Core rule engine contracts', () => {
 
   it('exposes the built-in core rule pack placeholder from the core boundary', () => {
     expect(CORE_BUILT_IN_RULE_PACK_ID).toBe('core');
-    expect(coreBuiltInRulePack).toEqual({
-      id: 'core',
-      name: 'Governance Core Built-in Rules',
-      rules: [],
-    });
+    expect(coreBuiltInRulePack.id).toBe('core');
+    expect(coreBuiltInRulePack.name).toBe('Governance Core Built-in Rules');
+    expect(coreBuiltInRulePack.rules.map((rule) => rule.id)).toEqual([
+      'domain-boundary',
+      'layer-boundary',
+      'ownership-presence',
+    ]);
     expect(coreBuiltInRulePacks).toEqual([coreBuiltInRulePack]);
   });
 });

--- a/packages/governance/src/policy-engine/evaluate-policies.ts
+++ b/packages/governance/src/policy-engine/evaluate-policies.ts
@@ -1,5 +1,5 @@
 import {
-  deriveAllowedLayerDependenciesFromLayerOrder,
+  evaluateCoreBuiltInPolicyViolations,
   GovernanceProfile,
   GovernanceWorkspace,
   Violation,
@@ -9,131 +9,8 @@ export function evaluatePolicies(
   workspace: GovernanceWorkspace,
   profile: GovernanceProfile
 ): Violation[] {
-  const violations: Violation[] = [];
-  const projectByName = new Map(
-    workspace.projects.map((project) => [project.name, project])
-  );
-  const declaredLayers = new Set(profile.layers);
-  const usesExplicitLayerDependencies =
-    profile.allowedLayerDependencies !== undefined;
-  const allowedLayerDependencies =
-    profile.allowedLayerDependencies ??
-    deriveAllowedLayerDependenciesFromLayerOrder(profile.layers);
-
-  for (const dependency of workspace.dependencies) {
-    const source = projectByName.get(dependency.source);
-    const target = projectByName.get(dependency.target);
-
-    if (!source || !target) {
-      continue;
-    }
-
-    if (
-      source.domain &&
-      target.domain &&
-      source.domain !== target.domain &&
-      !isDomainDependencyAllowed(profile, source.domain, target.domain)
-    ) {
-      violations.push({
-        id: `${source.name}-${target.name}-domain`,
-        ruleId: 'domain-boundary',
-        project: source.name,
-        severity: 'error',
-        category: 'boundary',
-        message: `Project ${source.name} in domain ${source.domain} depends on ${target.name} in domain ${target.domain}.`,
-        details: {
-          targetProject: target.name,
-          sourceDomain: source.domain,
-          targetDomain: target.domain,
-          dependencyType: dependency.type,
-        },
-        recommendation:
-          'Move the dependency behind an API or adjust domain boundaries in the governance profile.',
-      });
-    }
-
-    if (
-      source.layer &&
-      target.layer &&
-      declaredLayers.has(source.layer) &&
-      declaredLayers.has(target.layer) &&
-      !isLayerDependencyAllowed(
-        allowedLayerDependencies,
-        source.layer,
-        target.layer
-      )
-    ) {
-      violations.push({
-        id: `${source.name}-${target.name}-layer`,
-        ruleId: 'layer-boundary',
-        project: source.name,
-        severity: 'warning',
-        category: 'boundary',
-        message: `Layer violation: ${source.name} (${source.layer}) depends on ${target.name} (${target.layer}).`,
-        details: {
-          targetProject: target.name,
-          sourceLayer: source.layer,
-          targetLayer: target.layer,
-          ...(usesExplicitLayerDependencies
-            ? {
-                allowedTargets: allowedLayerDependencies[source.layer] ?? [],
-              }
-            : {
-                order: profile.layers,
-              }),
-        },
-        recommendation: usesExplicitLayerDependencies
-          ? 'Refactor the dependency or update allowedLayerDependencies in the governance profile when the dependency is intentional.'
-          : 'Refactor dependency direction so higher-level layers depend on same or lower-level layers only.',
-      });
-    }
-  }
-
-  if (profile.ownership.required) {
-    for (const project of workspace.projects) {
-      if (
-        !project.ownership?.team &&
-        !(project.ownership?.contacts?.length ?? 0)
-      ) {
-        violations.push({
-          id: `${project.name}-ownership`,
-          ruleId: 'ownership-presence',
-          project: project.name,
-          severity: 'warning',
-          category: 'ownership',
-          message: `Project ${project.name} has no ownership metadata or CODEOWNERS mapping.`,
-          recommendation:
-            'Add ownership metadata in project configuration or ensure CODEOWNERS covers the project root.',
-        });
-      }
-    }
-  }
-
-  return violations;
-}
-
-function isDomainDependencyAllowed(
-  profile: GovernanceProfile,
-  sourceDomain: string,
-  targetDomain: string
-): boolean {
-  const direct = profile.allowedDomainDependencies[sourceDomain];
-  if (direct && (direct.includes(targetDomain) || direct.includes('*'))) {
-    return true;
-  }
-
-  const wildcard = profile.allowedDomainDependencies['*'];
-  if (wildcard && (wildcard.includes(targetDomain) || wildcard.includes('*'))) {
-    return true;
-  }
-
-  return false;
-}
-
-function isLayerDependencyAllowed(
-  allowedLayerDependencies: Record<string, string[]>,
-  sourceLayer: string,
-  targetLayer: string
-): boolean {
-  return (allowedLayerDependencies[sourceLayer] ?? []).includes(targetLayer);
+  return evaluateCoreBuiltInPolicyViolations({
+    workspace,
+    profile,
+  });
 }


### PR DESCRIPTION
closes #244