### PR TITLE
init(governance-adapter-nx): Rewire Nx adapter to consume released Governance Core package

### DIFF
--- a/packages/governance-adapter-nx/README.md
+++ b/packages/governance-adapter-nx/README.md
@@ -39,6 +39,8 @@ This package does not own:
 
 Those remain in `@anarchitects/nx-governance`.
 
+The host package rewiring step is tracked separately in Plugins `#385`.
+
 ## Installation
 
 Consumers should install the host package:

--- a/packages/governance-adapter-nx/eslint.config.mjs
+++ b/packages/governance-adapter-nx/eslint.config.mjs
@@ -36,11 +36,23 @@ export default [
               message:
                 'The Nx adapter package must not depend on Nx host package internals.',
             },
+            {
+              name: '@anarchitects/governance-cli',
+              message:
+                'The Nx adapter package must not depend on the standalone Governance CLI package.',
+            },
+            {
+              name: '@anarchitects/governance-adapter-typescript',
+              message:
+                'The Nx adapter package must not depend on the TypeScript adapter package.',
+            },
           ],
           patterns: [
             {
               group: [
                 '@anarchitects/nx-governance/*',
+                '@anarchitects/governance-cli/*',
+                '@anarchitects/governance-adapter-typescript/*',
                 '@anarchitects/governance-core/*',
                 '**/governance/src/core/**',
                 '**/governance/src/plugin/**',

--- a/packages/governance-adapter-nx/src/adapter-boundaries.spec.ts
+++ b/packages/governance-adapter-nx/src/adapter-boundaries.spec.ts
@@ -26,6 +26,19 @@ describe('governance adapter nx boundary enforcement', () => {
           matchImport(line, /^@anarchitects\/nx-governance(?:\/|$)/),
       },
       {
+        rule: 'Adapter must not import the standalone Governance CLI package.',
+        test: (line) =>
+          matchImport(line, /^@anarchitects\/governance-cli(?:\/|$)/),
+      },
+      {
+        rule: 'Adapter must not import the TypeScript adapter package.',
+        test: (line) =>
+          matchImport(
+            line,
+            /^@anarchitects\/governance-adapter-typescript(?:\/|$)/
+          ),
+      },
+      {
         rule: 'Adapter must import Governance Core from the published package root only.',
         test: (line) => matchImport(line, /^@anarchitects\/governance-core\//),
       },


### PR DESCRIPTION
closes #384