### PR TITLE
feat(nx-governance): migrate governance executors and commands to canonical graph model

### DIFF
--- a/packages/governance/README.md
+++ b/packages/governance/README.md
@@ -31,6 +31,25 @@ Compatibility regression coverage for the split package topology lives in:
 - `packages/governance/src/compatibility/public-workflows.spec.ts`
 - `packages/governance/src/compatibility/host-adapter-core-flow.spec.ts`
 
+## Runtime composition
+
+`@anarchitects/nx-governance` remains the Governance composition root for Nx.
+
+Executors and command entrypoints are thin runtime wrappers. They preserve the existing executor names, command names, and runtime options, then delegate Governance execution to the host pipeline. They do not perform adapter extraction, extension registration, rule evaluation, metric calculation, recommendation generation, or adapter/extension/Core composition themselves.
+
+The host pipeline owns the composition flow:
+
+```text
+executor or command
+  -> @anarchitects/nx-governance host
+    -> @anarchitects/governance-adapter-nx
+    -> @anarchitects/governance-extension-nx
+    -> @anarchitects/governance-core
+    -> host-owned output routing and artifact generation
+```
+
+Executors remain owned by `@anarchitects/nx-governance`. Generators remain owned by `@anarchitects/nx-governance`. Phase 2 changes how they invoke Governance; it does not relocate them.
+
 ---
 
 ## Table of contents

--- a/packages/governance/src/executors/executor-boundaries.spec.ts
+++ b/packages/governance/src/executors/executor-boundaries.spec.ts
@@ -1,0 +1,130 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+interface BoundaryViolation {
+  file: string;
+  line: number;
+  matched: string;
+  rule: string;
+}
+
+interface BoundaryRule {
+  rule: string;
+  test: (line: string) => string | null;
+}
+
+const executorsRoot = path.resolve(__dirname);
+
+describe('governance executor boundary enforcement', () => {
+  it('keeps executors thin and routed through host command APIs', () => {
+    const files = collectImplementationFiles(executorsRoot);
+
+    const violations = scanBoundaryViolations(files, [
+      {
+        rule: 'Executors must not import the Nx governance adapter package directly.',
+        test: (line) =>
+          matchImport(line, /^@anarchitects\/governance-adapter-nx(?:\/|$)/),
+      },
+      {
+        rule: 'Executors must not import the Nx governance extension package directly.',
+        test: (line) =>
+          matchImport(line, /^@anarchitects\/governance-extension-nx(?:\/|$)/),
+      },
+      {
+        rule: 'Executors must not import rule implementation modules directly.',
+        test: (line) =>
+          matchImport(line, /(?:^|\/)(?:core|policy-engine)\/.*rules/),
+      },
+      {
+        rule: 'Executors must not import metric implementation modules directly.',
+        test: (line) =>
+          matchImport(line, /(?:^|\/)(?:metric-engine|delivery-impact)\//),
+      },
+      {
+        rule: 'Executors must not import recommendation implementation modules directly.',
+        test: (line) => matchImport(line, /recommendations/),
+      },
+    ]);
+
+    expectBoundaryViolationsToBeEmpty(
+      violations,
+      'Governance executor boundary violations detected.'
+    );
+  });
+});
+
+function collectImplementationFiles(directory: string): string[] {
+  const collected: string[] = [];
+
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const resolved = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      collected.push(...collectImplementationFiles(resolved));
+      continue;
+    }
+
+    if (
+      entry.isFile() &&
+      resolved.endsWith('.ts') &&
+      !resolved.endsWith('.spec.ts') &&
+      !resolved.endsWith('.test.ts')
+    ) {
+      collected.push(resolved);
+    }
+  }
+
+  return collected.sort((left, right) => left.localeCompare(right));
+}
+
+function scanBoundaryViolations(
+  files: string[],
+  rules: BoundaryRule[]
+): BoundaryViolation[] {
+  const violations: BoundaryViolation[] = [];
+
+  for (const file of files) {
+    const lines = readFileSync(file, 'utf8').split('\n');
+
+    lines.forEach((line, index) => {
+      for (const rule of rules) {
+        const matched = rule.test(line);
+        if (!matched) {
+          continue;
+        }
+
+        violations.push({
+          file: path.relative(executorsRoot, file),
+          line: index + 1,
+          matched,
+          rule: rule.rule,
+        });
+      }
+    });
+  }
+
+  return violations;
+}
+
+function matchImport(line: string, pattern: RegExp): string | null {
+  const match = line.match(/from ['"]([^'"]+)['"]/);
+  if (!match) {
+    return null;
+  }
+
+  return pattern.test(match[1]) ? match[1] : null;
+}
+
+function expectBoundaryViolationsToBeEmpty(
+  violations: BoundaryViolation[],
+  message: string
+): void {
+  const formatted = violations.map(
+    (violation) =>
+      `${violation.file}:${violation.line} ${violation.rule} (${violation.matched})`
+  );
+
+  if (formatted.length > 0) {
+    throw new Error(`${message}\n${formatted.join('\n')}`);
+  }
+}

--- a/packages/governance/src/executors/workspace-graph/executor.spec.ts
+++ b/packages/governance/src/executors/workspace-graph/executor.spec.ts
@@ -14,29 +14,18 @@ describe('workspace-graph executor', () => {
     ).toBe('Projects: 4\nDependencies: 9');
   });
 
-  it('prints project and dependency counts from the adapter snapshot', async () => {
+  it('prints project and dependency counts from the host composition summary', async () => {
     const info = jest.fn();
     const error = jest.fn();
-    const readSnapshot = jest.fn().mockResolvedValue({
-      source: 'nx-graph' as const,
-      extractedAt: '2026-03-17T00:00:00.000Z',
-      projects: [
-        { id: 'a', name: 'a', type: 'library', tags: [] },
-        { id: 'b', name: 'b', type: 'library', tags: [] },
-      ],
-      dependencies: [
-        { sourceProjectId: 'a', targetProjectId: 'b', type: 'static' },
-      ],
+    const summarizeGraph = jest.fn().mockResolvedValue({
+      summary: { projectCount: 2, dependencyCount: 1 },
+      source: 'host-canonical-workspace',
     });
-    const summarize = jest
-      .fn()
-      .mockReturnValue({ projectCount: 2, dependencyCount: 1 });
 
     const result = await runWorkspaceGraphExecutor(
-      {},
+      { graphJson: 'dist/project-graph.json' },
       {
-        readSnapshot,
-        summarize,
+        summarizeGraph,
         info,
         error,
       }
@@ -45,20 +34,22 @@ describe('workspace-graph executor', () => {
     expect(result).toEqual({ success: true });
     expect(info).toHaveBeenCalledWith('Projects: 2\nDependencies: 1');
     expect(error).not.toHaveBeenCalled();
-    expect(readSnapshot).toHaveBeenCalledWith({});
+    expect(summarizeGraph).toHaveBeenCalledWith({
+      graphJson: 'dist/project-graph.json',
+    });
   });
 
   it('returns unsuccessful when graph loading fails', async () => {
     const info = jest.fn();
     const error = jest.fn();
-    const readSnapshot = jest.fn().mockRejectedValue(new Error('graph failed'));
-    const summarize = jest.fn();
+    const summarizeGraph = jest
+      .fn()
+      .mockRejectedValue(new Error('graph failed'));
 
     const result = await runWorkspaceGraphExecutor(
       {},
       {
-        readSnapshot,
-        summarize,
+        summarizeGraph,
         info,
         error,
       }
@@ -67,6 +58,5 @@ describe('workspace-graph executor', () => {
     expect(result).toEqual({ success: false });
     expect(error).toHaveBeenCalledWith('graph failed');
     expect(info).not.toHaveBeenCalled();
-    expect(summarize).not.toHaveBeenCalled();
   });
 });

--- a/packages/governance/src/executors/workspace-graph/executor.ts
+++ b/packages/governance/src/executors/workspace-graph/executor.ts
@@ -1,12 +1,12 @@
 import { logger } from '@nx/devkit';
 
-import {
-  GraphSummary,
-  WorkspaceGraphSnapshot,
-  readWorkspaceGraphSnapshot,
-  summarizeWorkspaceGraph,
-} from '@anarchitects/governance-adapter-nx';
+import { summarizeNxGovernanceWorkspaceGraph } from '../../plugin/compose-governance-runtime.js';
 import { WorkspaceGraphExecutorOptions } from '../types.js';
+
+interface GraphSummary {
+  projectCount: number;
+  dependencyCount: number;
+}
 
 export default async function workspaceGraphExecutor(
   options: WorkspaceGraphExecutorOptions = {}
@@ -15,20 +15,18 @@ export default async function workspaceGraphExecutor(
 }
 
 interface WorkspaceGraphExecutorDeps {
-  readSnapshot: (
+  summarizeGraph: (
     options: WorkspaceGraphExecutorOptions
-  ) => Promise<WorkspaceGraphSnapshot>;
-  summarize: (snapshot: WorkspaceGraphSnapshot) => GraphSummary;
+  ) => Promise<{ summary: GraphSummary }>;
   info: (message: string) => void;
   error: (message: string) => void;
 }
 
 const defaultDeps: WorkspaceGraphExecutorDeps = {
-  readSnapshot: (options) =>
-    readWorkspaceGraphSnapshot({
+  summarizeGraph: (options) =>
+    summarizeNxGovernanceWorkspaceGraph({
       graphJson: options.graphJson,
     }),
-  summarize: (snapshot) => summarizeWorkspaceGraph(snapshot),
   info: (message) => logger.info(message),
   error: (message) => logger.error(message),
 };
@@ -38,8 +36,7 @@ export async function runWorkspaceGraphExecutor(
   deps: WorkspaceGraphExecutorDeps = defaultDeps
 ): Promise<{ success: boolean }> {
   try {
-    const snapshot = await deps.readSnapshot(options);
-    const summary = deps.summarize(snapshot);
+    const { summary } = await deps.summarizeGraph(options);
 
     deps.info(renderWorkspaceGraphSummary(summary));
     return { success: true };

--- a/packages/governance/src/plugin/compose-governance-runtime.spec.ts
+++ b/packages/governance/src/plugin/compose-governance-runtime.spec.ts
@@ -22,7 +22,10 @@ import type {
 import { loadNxGovernanceWorkspaceContext } from '@anarchitects/governance-adapter-nx';
 
 import { registerNxGovernanceExtensionsWithDiagnostics } from '../nx-host/extensions/host.js';
-import { composeNxGovernanceRuntime } from './compose-governance-runtime.js';
+import {
+  composeNxGovernanceRuntime,
+  summarizeNxGovernanceWorkspaceGraph,
+} from './compose-governance-runtime.js';
 
 const mockedLoadNxGovernanceWorkspaceContext = jest.mocked(
   loadNxGovernanceWorkspaceContext
@@ -207,6 +210,48 @@ describe('composeNxGovernanceRuntime', () => {
     expect(result.artifacts.extensionDiagnostics).toEqual([
       expect.objectContaining({ code: 'governance.extension.loaded' }),
     ]);
+  });
+
+  it('summarizes the workspace graph through canonical host adapter output', async () => {
+    mockedLoadNxGovernanceWorkspaceContext.mockResolvedValue({
+      adapterResult: {
+        workspaceRoot,
+        nodes: [
+          { id: 'app', kind: 'project' },
+          { id: 'shared-data', kind: 'project' },
+        ],
+        relations: [
+          {
+            sourceNodeId: 'app',
+            targetNodeId: 'shared-data',
+            kind: 'dependency',
+          },
+        ],
+        projects: [
+          { id: 'legacy-app' },
+          { id: 'legacy-shared-data' },
+          { id: 'legacy-extra' },
+        ],
+        dependencies: [],
+      },
+      snapshot: {
+        root: workspaceRoot,
+        projects: [],
+        dependencies: [],
+        codeownersByProject: {},
+      },
+    });
+
+    const result = await summarizeNxGovernanceWorkspaceGraph();
+
+    expect(result).toEqual({
+      summary: {
+        projectCount: 2,
+        dependencyCount: 1,
+      },
+      source: 'host-canonical-workspace',
+    });
+    expect(mockedLoadNxGovernanceWorkspaceContext).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/governance/src/plugin/compose-governance-runtime.ts
+++ b/packages/governance/src/plugin/compose-governance-runtime.ts
@@ -11,7 +11,13 @@ import {
   type GovernanceWorkspaceAdapterResult,
   type ProfileOverrides,
 } from '@anarchitects/governance-core';
-import { loadNxGovernanceWorkspaceContext } from '@anarchitects/governance-adapter-nx';
+import {
+  loadNxGovernanceWorkspaceContext,
+  readWorkspaceGraphSnapshot,
+  summarizeWorkspaceGraph,
+  type GraphAdapterOptions,
+  type GraphSummary,
+} from '@anarchitects/governance-adapter-nx';
 
 import { loadGovernanceExtensionConfig } from '../nx-host/extensions/config.js';
 import { registerNxGovernanceExtensionsWithDiagnostics } from '../nx-host/extensions/host.js';
@@ -37,6 +43,13 @@ export interface ComposeNxGovernanceRuntimeResult {
   extensionContext: GovernanceExtensionHostContext;
   extensionRegistration: GovernanceExtensionRegistrationResult;
   artifacts: GovernanceAssessmentArtifacts;
+}
+
+export type NxGovernanceWorkspaceGraphSummaryInput = GraphAdapterOptions;
+
+export interface NxGovernanceWorkspaceGraphSummaryResult {
+  summary: GraphSummary;
+  source: 'host-canonical-workspace' | 'adapter-graph-json';
 }
 
 export async function composeNxGovernanceRuntime(
@@ -81,5 +94,34 @@ export async function composeNxGovernanceRuntime(
     extensionContext,
     extensionRegistration,
     artifacts,
+  };
+}
+
+export async function summarizeNxGovernanceWorkspaceGraph(
+  input: NxGovernanceWorkspaceGraphSummaryInput = {}
+): Promise<NxGovernanceWorkspaceGraphSummaryResult> {
+  if (input.graphJson) {
+    const snapshot = await readWorkspaceGraphSnapshot({
+      graphJson: input.graphJson,
+    });
+
+    return {
+      summary: summarizeWorkspaceGraph(snapshot),
+      source: 'adapter-graph-json',
+    };
+  }
+
+  const { adapterResult } = await loadNxGovernanceWorkspaceContext();
+
+  return {
+    summary: {
+      projectCount:
+        adapterResult.nodes?.length ?? adapterResult.projects?.length ?? 0,
+      dependencyCount:
+        adapterResult.relations?.length ??
+        adapterResult.dependencies?.length ??
+        0,
+    },
+    source: 'host-canonical-workspace',
   };
 }


### PR DESCRIPTION
closes #411