### PR TITLE
fix(governance-adapter-nx): repo-health treats Nx workspace root task container as a governed project node

### DIFF
--- a/packages/governance-adapter-nx/src/read-workspace.spec.ts
+++ b/packages/governance-adapter-nx/src/read-workspace.spec.ts
@@ -6,8 +6,10 @@ import { tmpdir } from 'node:os';
 import type { GovernanceWorkspaceAdapterResult } from '@anarchitects/governance-core';
 
 import {
+  createNxWorkspaceSnapshotFromProjectGraph,
   createNxWorkspaceAdapterResult,
   discoverGovernanceProfileFiles,
+  isDefaultWorkspaceRootTaskContainerProject,
   readNxWorkspaceSnapshot,
   resolveProjectTagsAndMetadata,
 } from './read-workspace.js';
@@ -256,6 +258,161 @@ describe('read-workspace adapter compatibility', () => {
         sourceSystem: 'nx',
       },
     });
+  });
+
+  it('excludes the default workspace root task container from snapshot projects, relations, and capabilities', () => {
+    const snapshot = createNxWorkspaceSnapshotFromProjectGraph(
+      {
+        nodes: {
+          source: {
+            type: 'lib',
+            name: 'source',
+            data: {
+              root: '.',
+              projectType: 'unknown',
+              targets: {
+                'repo-health': {},
+                'workspace-graph': {},
+              },
+              metadata: {
+                js: {
+                  isInPackageManagerWorkspaces: true,
+                  packageName: '@nx-workspace/source',
+                  packageVersion: '0.0.0',
+                },
+                targetGroups: {},
+              },
+            },
+          },
+          orders: {
+            type: 'lib',
+            name: 'orders',
+            data: {
+              root: 'libs/orders',
+              sourceRoot: 'libs/orders/src',
+              projectType: 'library',
+              tags: ['domain:orders', 'layer:feature'],
+              targets: {
+                build: {},
+                test: {},
+              },
+              metadata: {
+                documentation: true,
+              },
+            },
+          },
+          shared: {
+            type: 'lib',
+            name: 'shared',
+            data: {
+              root: 'libs/shared',
+              sourceRoot: 'libs/shared/src',
+              projectType: 'library',
+              tags: ['domain:shared', 'layer:util'],
+              targets: {
+                lint: {},
+              },
+              metadata: {
+                ownership: {
+                  team: '@org/shared',
+                },
+              },
+            },
+          },
+        },
+        dependencies: {
+          source: [{ target: 'orders', type: 'implicit' }],
+          orders: [{ target: 'shared', type: 'static' }],
+          shared: [{ target: 'source', type: 'dynamic' }],
+        },
+      } as unknown as Awaited<
+        ReturnType<typeof nxDevkit.createProjectGraphAsync>
+      >,
+      testRoot
+    );
+
+    expect(snapshot.projects.map((project) => project.name)).toEqual([
+      'orders',
+      'shared',
+    ]);
+    expect(snapshot.dependencies).toEqual([
+      {
+        source: 'orders',
+        target: 'shared',
+        type: 'static',
+      },
+    ]);
+    expect(Object.keys(snapshot.codeownersByProject)).toEqual([
+      'orders',
+      'shared',
+    ]);
+
+    const result = createNxWorkspaceAdapterResult(snapshot);
+    const capabilityIds = [
+      'capability:nx',
+      'nx.project-graph',
+      'nx.project-metadata',
+      'nx.project-tags',
+      'nx.targets',
+    ];
+
+    expect(result.nodes?.map((node) => node.id)).toEqual(['orders', 'shared']);
+    expect(result.relations?.map((relation) => relation.sourceNodeId)).toEqual([
+      'orders',
+    ]);
+    for (const capabilityId of capabilityIds) {
+      const projects = (
+        result.capabilities?.find(
+          (capability) => capability.id === capabilityId
+        )?.data as
+          | {
+              projects?: Array<{ id?: string; name?: string }>;
+            }
+          | undefined
+      )?.projects;
+      expect(
+        projects?.some(
+          (project) => project.id === 'source' || project.name === 'source'
+        ) ?? false
+      ).toBe(false);
+    }
+  });
+
+  it('keeps an explicitly governed root project when governance tags or metadata are present', () => {
+    expect(
+      isDefaultWorkspaceRootTaskContainerProject({
+        name: 'workspace',
+        root: '.',
+        type: 'unknown',
+        tags: ['domain:workspace', 'layer:tooling'],
+        targets: ['repo-health'],
+        metadata: {
+          js: {
+            isInPackageManagerWorkspaces: true,
+            packageName: '@nx-workspace/source',
+          },
+        },
+      })
+    ).toBe(false);
+
+    expect(
+      isDefaultWorkspaceRootTaskContainerProject({
+        name: 'workspace',
+        root: '.',
+        type: 'unknown',
+        targets: ['repo-health'],
+        metadata: {
+          js: {
+            isInPackageManagerWorkspaces: true,
+            packageName: '@nx-workspace/source',
+          },
+          ownership: {
+            team: '@org/platform',
+          },
+          documentation: false,
+        },
+      })
+    ).toBe(false);
   });
 
   it('discovers governance profile files without requiring host composition', () => {

--- a/packages/governance-adapter-nx/src/read-workspace.ts
+++ b/packages/governance-adapter-nx/src/read-workspace.ts
@@ -8,6 +8,11 @@ import type {
 } from '@anarchitects/governance-core';
 
 import { ownersForProjectRoot, readCodeowners } from './codeowners.js';
+import {
+  hasCanonicalOwnershipData,
+  readCanonicalOwnershipFromProjectMetadata,
+} from './ownership.js';
+import { hasTagWithPrefix } from './tag-parsing.js';
 import { toGovernanceWorkspaceAdapterResult } from './to-governance-workspace-adapter-result.js';
 import type { AdapterWorkspaceSnapshot } from './types.js';
 
@@ -18,43 +23,15 @@ export interface NxGovernanceWorkspaceContext {
 
 export async function readNxWorkspaceSnapshot(): Promise<AdapterWorkspaceSnapshot> {
   const graph = await createProjectGraphAsync();
-  const codeownersEntries = readCodeowners(workspaceRoot);
+  return createNxWorkspaceSnapshotFromProjectGraph(graph, workspaceRoot);
+}
 
-  const projects = Object.values(graph.nodes)
-    .map((node) => {
-      const graphTags = Array.isArray(node.data.tags) ? node.data.tags : [];
-      const targets =
-        node.data.targets && typeof node.data.targets === 'object'
-          ? sortedStrings(Object.keys(node.data.targets))
-          : [];
-      const graphMetadata =
-        node.data.metadata && typeof node.data.metadata === 'object'
-          ? (node.data.metadata as Record<string, unknown>)
-          : {};
-      const { tags, metadata } = resolveProjectTagsAndMetadata(
-        node.data.root,
-        workspaceRoot,
-        graphTags,
-        graphMetadata
-      );
-
-      return {
-        name: node.name,
-        root: node.data.root,
-        ...(asString(node.data.sourceRoot)
-          ? { sourceRoot: asString(node.data.sourceRoot) }
-          : {}),
-        type: node.data.projectType ?? 'unknown',
-        tags,
-        targets,
-        implicitDependencies: sortedStrings(
-          toStringArray(node.data.implicitDependencies)
-        ),
-        metadata,
-      };
-    })
-    .sort((left, right) => left.name.localeCompare(right.name));
-
+export function createNxWorkspaceSnapshotFromProjectGraph(
+  graph: Awaited<ReturnType<typeof createProjectGraphAsync>>,
+  rootPath: string
+): AdapterWorkspaceSnapshot {
+  const codeownersEntries = readCodeowners(rootPath);
+  const projects = normalizeNxProjectGraphNodes(graph.nodes, rootPath);
   const projectNames = new Set(projects.map((project) => project.name));
   const diagnostics: GovernanceDiagnostic[] = [];
 
@@ -128,16 +105,61 @@ export async function readNxWorkspaceSnapshot(): Promise<AdapterWorkspaceSnapsho
       ownersForProjectRoot(project.root, codeownersEntries),
     ])
   );
-  const governanceProfileFiles = discoverGovernanceProfileFiles(workspaceRoot);
+  const governanceProfileFiles = discoverGovernanceProfileFiles(rootPath);
 
   return {
-    root: workspaceRoot,
+    root: rootPath,
     projects,
     dependencies,
     codeownersByProject,
     ...(governanceProfileFiles.length > 0 ? { governanceProfileFiles } : {}),
     ...(diagnostics.length > 0 ? { diagnostics } : {}),
   };
+}
+
+type NxProjectGraphNode = Awaited<
+  ReturnType<typeof createProjectGraphAsync>
+>['nodes'][string];
+
+export function normalizeNxProjectGraphNodes(
+  nodes: Record<string, NxProjectGraphNode>,
+  rootPath: string
+): AdapterWorkspaceSnapshot['projects'] {
+  return Object.values(nodes)
+    .map((node) => {
+      const graphTags = Array.isArray(node.data.tags) ? node.data.tags : [];
+      const targets =
+        node.data.targets && typeof node.data.targets === 'object'
+          ? sortedStrings(Object.keys(node.data.targets))
+          : [];
+      const graphMetadata =
+        node.data.metadata && typeof node.data.metadata === 'object'
+          ? (node.data.metadata as Record<string, unknown>)
+          : {};
+      const { tags, metadata } = resolveProjectTagsAndMetadata(
+        node.data.root,
+        rootPath,
+        graphTags,
+        graphMetadata
+      );
+
+      return {
+        name: node.name,
+        root: node.data.root,
+        ...(asString(node.data.sourceRoot)
+          ? { sourceRoot: asString(node.data.sourceRoot) }
+          : {}),
+        type: node.data.projectType ?? 'unknown',
+        tags,
+        targets,
+        implicitDependencies: sortedStrings(
+          toStringArray(node.data.implicitDependencies)
+        ),
+        metadata,
+      };
+    })
+    .filter((project) => !isDefaultWorkspaceRootTaskContainerProject(project))
+    .sort((left, right) => left.name.localeCompare(right.name));
 }
 
 export function createNxWorkspaceAdapterResult(
@@ -209,6 +231,42 @@ export function discoverGovernanceProfileFiles(rootPath: string): string[] {
   }
 }
 
+export function isDefaultWorkspaceRootTaskContainerProject(
+  projectLike: Partial<AdapterWorkspaceSnapshot['projects'][number]>
+): boolean {
+  if (projectLike.root !== '.' || projectLike.type !== 'unknown') {
+    return false;
+  }
+
+  if (asString(projectLike.sourceRoot)) {
+    return false;
+  }
+
+  const metadata = asRecord(projectLike.metadata) ?? {};
+  const jsMetadata = asRecord(metadata.js);
+  const tags = toStringArray(projectLike.tags);
+
+  if (jsMetadata?.isInPackageManagerWorkspaces !== true) {
+    return false;
+  }
+
+  if (!asString(jsMetadata.packageName)) {
+    return false;
+  }
+
+  if (
+    hasArchitecturalGovernanceClassification(tags) ||
+    hasCanonicalOwnershipData(
+      readCanonicalOwnershipFromProjectMetadata(metadata)
+    ) ||
+    hasCanonicalDocumentationMetadata(metadata)
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
 function nxDependencyMetadata(edge: unknown): Record<string, unknown> {
   const record = asRecord(edge);
   if (!record) {
@@ -221,6 +279,21 @@ function nxDependencyMetadata(edge: unknown): Record<string, unknown> {
         !['source', 'target', 'type', 'sourceFile'].includes(key) &&
         value !== undefined
     )
+  );
+}
+
+function hasArchitecturalGovernanceClassification(tags: string[]): boolean {
+  return ['domain', 'layer', 'scope'].some((prefix) =>
+    hasTagWithPrefix(tags, prefix)
+  );
+}
+
+function hasCanonicalDocumentationMetadata(
+  metadata: Record<string, unknown>
+): boolean {
+  return (
+    Object.prototype.hasOwnProperty.call(metadata, 'documentation') ||
+    Object.prototype.hasOwnProperty.call(metadata, 'documented')
   );
 }
 


### PR DESCRIPTION
closes #469