### PR TITLE
fix(nx-governance,governance-adapter-nx): adapter treats generic Nx/package-manager tags as governance tags

### DIFF
--- a/packages/governance-adapter-nx/src/capability.spec.ts
+++ b/packages/governance-adapter-nx/src/capability.spec.ts
@@ -46,6 +46,7 @@ describe('createNxCapability', () => {
           root: 'libs/booking/ui',
           type: 'library',
           tags: ['scope:booking', 'layer:ui'],
+          nxTags: ['scope:booking', 'layer:ui', 'npm:private'],
           targets: ['test', 'build'],
           metadata: {
             documentation: true,
@@ -73,7 +74,7 @@ describe('createNxCapability', () => {
             name: 'booking-ui',
             root: 'libs/booking/ui',
             type: 'library',
-            tags: ['scope:booking', 'layer:ui'],
+            tags: ['scope:booking', 'layer:ui', 'npm:private'],
             targets: ['build', 'test'],
           },
         ],
@@ -288,6 +289,7 @@ describe('createNxCapability', () => {
             root: 'libs/booking/ui',
             type: 'library',
             tags: ['scope:booking', 'layer:ui'],
+            nxTags: ['scope:booking', 'layer:ui', 'npm:private'],
             targets: ['test', 'build'],
             metadata: {
               documentation: true,
@@ -321,7 +323,7 @@ describe('createNxCapability', () => {
       projects: [
         {
           id: 'booking-ui',
-          tags: ['scope:booking', 'layer:ui'],
+          tags: ['scope:booking', 'layer:ui', 'npm:private'],
         },
       ],
     });
@@ -350,6 +352,54 @@ describe('createNxCapability', () => {
           id: 'booking-ui',
           contacts: ['@booking-team'],
           source: 'codeowners',
+        },
+      ],
+    });
+  });
+
+  it('keeps raw Nx tags visible in capabilities even when canonical tags are narrower', () => {
+    const snapshot: AdapterWorkspaceSnapshot = {
+      root: '/workspace',
+      projects: [
+        {
+          name: 'booking-app',
+          root: 'apps/booking',
+          type: 'application',
+          tags: ['domain:booking', 'type: api'],
+          nxTags: ['domain:booking', 'type: api', 'npm:public'],
+          targets: [],
+          metadata: {},
+        },
+      ],
+      dependencies: [],
+      codeownersByProject: {},
+    };
+
+    expect(
+      createNxCapability({
+        workspaceRoot: '/workspace',
+        snapshot,
+      }).data?.projects
+    ).toEqual([
+      {
+        name: 'booking-app',
+        root: 'apps/booking',
+        type: 'application',
+        tags: ['domain:booking', 'type: api', 'npm:public'],
+        targets: [],
+      },
+    ]);
+    expect(
+      capabilityData(
+        createNxCapabilities({ workspaceRoot: '/workspace', snapshot }),
+        'nx.project-tags'
+      )
+    ).toEqual({
+      projectCount: 1,
+      projects: [
+        {
+          id: 'booking-app',
+          tags: ['domain:booking', 'type: api', 'npm:public'],
         },
       ],
     });

--- a/packages/governance-adapter-nx/src/capability.ts
+++ b/packages/governance-adapter-nx/src/capability.ts
@@ -42,7 +42,7 @@ export function createNxCapability(input: {
       name: project.name,
       root: project.root,
       ...(project.type ? { type: project.type } : {}),
-      tags: [...(project.tags ?? [])],
+      tags: [...readNxProjectTags(project)],
       targets: [...(project.targets ?? [])].sort((a, b) => a.localeCompare(b)),
     }))
     .sort((a, b) => a.name.localeCompare(b.name));
@@ -198,7 +198,7 @@ function createProjectTagsCapability(input: {
   const projects = input.snapshot.projects
     .map((project) => ({
       id: project.name,
-      tags: [...(project.tags ?? [])],
+      tags: [...readNxProjectTags(project)],
     }))
     .filter((project) => project.tags.length > 0)
     .sort((left, right) => left.id.localeCompare(right.id));
@@ -372,4 +372,10 @@ function createOwnershipEvidenceCapability(input: {
       evidenceSource: 'codeowners',
     },
   };
+}
+
+function readNxProjectTags(
+  project: AdapterWorkspaceSnapshot['projects'][number]
+): string[] {
+  return [...(project.nxTags ?? project.tags ?? [])];
 }

--- a/packages/governance-adapter-nx/src/read-workspace.spec.ts
+++ b/packages/governance-adapter-nx/src/read-workspace.spec.ts
@@ -138,6 +138,7 @@ describe('read-workspace adapter compatibility', () => {
           sourceRoot: 'libs/booking/ui/src',
           type: 'library',
           tags: ['scope:booking', 'layer:ui'],
+          nxTags: ['scope:booking', 'layer:ui', 'type:ui'],
           targets: ['build', 'test'],
           implicitDependencies: ['shared'],
           metadata: {
@@ -178,7 +179,7 @@ describe('read-workspace adapter compatibility', () => {
             projectType: 'library',
             root: 'libs/booking/ui',
             sourceRoot: 'libs/booking/ui/src',
-            tags: ['scope:booking', 'layer:ui'],
+            tags: ['scope:booking', 'layer:ui', 'type:ui'],
             targets: ['build', 'test'],
             implicitDependencies: ['shared'],
             projectMetadata: {
@@ -204,7 +205,7 @@ describe('read-workspace adapter compatibility', () => {
                 name: 'booking-ui',
                 root: 'libs/booking/ui',
                 type: 'library',
-                tags: ['scope:booking', 'layer:ui'],
+                tags: ['scope:booking', 'layer:ui', 'type:ui'],
                 targets: ['build', 'test'],
               },
             ],
@@ -258,6 +259,48 @@ describe('read-workspace adapter compatibility', () => {
         sourceSystem: 'nx',
       },
     });
+  });
+
+  it('splits canonical governance tags from raw Nx tags during snapshot normalization', () => {
+    const snapshot = createNxWorkspaceSnapshotFromProjectGraph(
+      {
+        nodes: {
+          booking: {
+            type: 'lib',
+            name: 'booking',
+            data: {
+              root: 'libs/booking',
+              sourceRoot: 'libs/booking/src',
+              projectType: 'library',
+              tags: ['domain:booking', 'npm:private', 'type: api'],
+              targets: {
+                test: {},
+              },
+            },
+          },
+        },
+        dependencies: {
+          booking: [],
+        },
+      } as unknown as Awaited<
+        ReturnType<typeof nxDevkit.createProjectGraphAsync>
+      >,
+      testRoot
+    );
+
+    expect(snapshot.projects).toEqual([
+      {
+        name: 'booking',
+        root: 'libs/booking',
+        sourceRoot: 'libs/booking/src',
+        type: 'library',
+        tags: ['domain:booking', 'type: api'],
+        nxTags: ['domain:booking', 'npm:private', 'type: api'],
+        targets: ['test'],
+        implicitDependencies: [],
+        metadata: {},
+      },
+    ]);
   });
 
   it('excludes the default workspace root task container from snapshot projects, relations, and capabilities', () => {

--- a/packages/governance-adapter-nx/src/read-workspace.ts
+++ b/packages/governance-adapter-nx/src/read-workspace.ts
@@ -12,7 +12,7 @@ import {
   hasCanonicalOwnershipData,
   readCanonicalOwnershipFromProjectMetadata,
 } from './ownership.js';
-import { hasTagWithPrefix } from './tag-parsing.js';
+import { hasTagWithPrefix, splitNxTags } from './tag-parsing.js';
 import { toGovernanceWorkspaceAdapterResult } from './to-governance-workspace-adapter-result.js';
 import type { AdapterWorkspaceSnapshot } from './types.js';
 
@@ -142,6 +142,7 @@ export function normalizeNxProjectGraphNodes(
         graphTags,
         graphMetadata
       );
+      const { governanceTags, rawTags } = splitNxTags(tags);
 
       return {
         name: node.name,
@@ -150,7 +151,8 @@ export function normalizeNxProjectGraphNodes(
           ? { sourceRoot: asString(node.data.sourceRoot) }
           : {}),
         type: node.data.projectType ?? 'unknown',
-        tags,
+        tags: governanceTags,
+        nxTags: rawTags,
         targets,
         implicitDependencies: sortedStrings(
           toStringArray(node.data.implicitDependencies)

--- a/packages/governance-adapter-nx/src/tag-parsing.spec.ts
+++ b/packages/governance-adapter-nx/src/tag-parsing.spec.ts
@@ -1,4 +1,9 @@
-import { hasTagWithPrefix, readTagValue } from './tag-parsing.js';
+import {
+  hasTagWithPrefix,
+  isDefaultExcludedNxTag,
+  readTagValue,
+  splitNxTags,
+} from './tag-parsing.js';
 
 describe('Nx tag parsing', () => {
   describe.each([
@@ -49,5 +54,54 @@ describe('Nx tag parsing', () => {
   it('ignores leading and trailing raw tag whitespace before prefix matching', () => {
     expect(readTagValue([' domain:booking '], 'domain')).toBe('booking');
     expect(readTagValue([' layer:domain '], 'layer')).toBe('domain');
+  });
+
+  it.each(['npm:private', 'npm:public', ' npm:keyword '])(
+    'treats "%s" as a default excluded Nx tag',
+    (tag) => {
+      expect(isDefaultExcludedNxTag(tag)).toBe(true);
+    }
+  );
+
+  it.each([
+    'domain:booking',
+    ' layer:application ',
+    'scope:payments',
+    'type:api',
+    'owner:platform',
+  ])(
+    'does not exclude "%s" from canonical governance tags by default',
+    (tag) => {
+      expect(isDefaultExcludedNxTag(tag)).toBe(false);
+    }
+  );
+
+  it('splits canonical governance tags from raw Nx tags while preserving order', () => {
+    expect(
+      splitNxTags([
+        'domain:booking',
+        'npm:private',
+        ' layer:application ',
+        'type:api',
+        'scope:customer',
+        'owner:platform',
+      ])
+    ).toEqual({
+      governanceTags: [
+        'domain:booking',
+        ' layer:application ',
+        'type:api',
+        'scope:customer',
+        'owner:platform',
+      ],
+      rawTags: [
+        'domain:booking',
+        'npm:private',
+        ' layer:application ',
+        'type:api',
+        'scope:customer',
+        'owner:platform',
+      ],
+    });
   });
 });

--- a/packages/governance-adapter-nx/src/tag-parsing.ts
+++ b/packages/governance-adapter-nx/src/tag-parsing.ts
@@ -17,3 +17,19 @@ export function readTagValue(
     .trim();
   return value.length > 0 ? value : undefined;
 }
+
+export function isDefaultExcludedNxTag(tag: string): boolean {
+  const normalizedTag = tag.trim();
+
+  return normalizedTag.startsWith('npm:');
+}
+
+export function splitNxTags(tags: string[]): {
+  governanceTags: string[];
+  rawTags: string[];
+} {
+  return {
+    governanceTags: tags.filter((tag) => !isDefaultExcludedNxTag(tag)),
+    rawTags: [...tags],
+  };
+}

--- a/packages/governance-adapter-nx/src/to-governance-workspace-adapter-result.spec.ts
+++ b/packages/governance-adapter-nx/src/to-governance-workspace-adapter-result.spec.ts
@@ -18,6 +18,7 @@ describe('toGovernanceWorkspaceAdapterResult', () => {
           sourceRoot: 'libs/booking/ui/src',
           type: 'library',
           tags: ['scope:booking', 'layer:ui', 'type:ui'],
+          nxTags: ['scope:booking', 'layer:ui', 'type:ui'],
           targets: ['test', 'build'],
           implicitDependencies: ['booking-domain'],
           metadata: {
@@ -30,6 +31,7 @@ describe('toGovernanceWorkspaceAdapterResult', () => {
           sourceRoot: 'libs/booking/domain/src',
           type: 'library',
           tags: ['scope:booking', 'layer:domain', 'type:domain'],
+          nxTags: ['scope:booking', 'layer:domain', 'type:domain'],
           targets: ['lint'],
           metadata: {
             ownership: {
@@ -220,6 +222,80 @@ describe('toGovernanceWorkspaceAdapterResult', () => {
       'nx.project-tags',
       'nx.targets',
     ]);
+  });
+
+  it('keeps inferred npm tags out of canonical node tags while preserving them in Nx metadata', () => {
+    const snapshot: AdapterWorkspaceSnapshot = {
+      root: '/workspace',
+      projects: [
+        {
+          name: 'booking-app',
+          root: 'apps/booking',
+          type: 'application',
+          tags: ['domain:booking', 'layer:application'],
+          nxTags: ['domain:booking', 'layer:application', 'npm:private'],
+          targets: [],
+          metadata: {},
+        },
+      ],
+      dependencies: [],
+      codeownersByProject: {},
+    };
+
+    const result = toGovernanceWorkspaceAdapterResult(snapshot);
+
+    expect(result.nodes).toEqual([
+      expect.objectContaining({
+        id: 'booking-app',
+        tags: ['domain:booking', 'layer:application'],
+        classification: {
+          domain: 'booking',
+          layer: 'application',
+          tags: ['domain:booking', 'layer:application'],
+        },
+        metadata: {
+          nx: expect.objectContaining({
+            tags: ['domain:booking', 'layer:application', 'npm:private'],
+          }),
+        },
+      }),
+    ]);
+  });
+
+  it('keeps generic tags canonical while not deriving classification from them alone', () => {
+    const snapshot: AdapterWorkspaceSnapshot = {
+      root: '/workspace',
+      projects: [
+        {
+          name: 'api',
+          root: 'apps/api',
+          type: 'application',
+          tags: ['type: api'],
+          nxTags: ['type: api'],
+          targets: [],
+          metadata: {},
+        },
+      ],
+      dependencies: [],
+      codeownersByProject: {},
+    };
+
+    const result = toGovernanceWorkspaceAdapterResult(snapshot);
+
+    expect(result.nodes).toEqual([
+      expect.objectContaining({
+        id: 'api',
+        tags: ['type: api'],
+        metadata: {
+          nx: expect.objectContaining({
+            tags: ['type: api'],
+          }),
+        },
+      }),
+    ]);
+    expect(result.nodes?.[0]?.classification).toEqual({
+      tags: ['type: api'],
+    });
   });
 
   it('uses project metadata ownership when CODEOWNERS ownership is absent', () => {

--- a/packages/governance-adapter-nx/src/to-governance-workspace-adapter-result.ts
+++ b/packages/governance-adapter-nx/src/to-governance-workspace-adapter-result.ts
@@ -121,7 +121,7 @@ export function nxNodeMetadata(
       projectType: project.type,
       root: project.root,
       ...(project.sourceRoot ? { sourceRoot: project.sourceRoot } : {}),
-      tags: [...(project.tags ?? [])],
+      tags: [...readNxProjectTags(project)],
       targets: [...(project.targets ?? [])],
       ...(project.implicitDependencies &&
       project.implicitDependencies.length > 0
@@ -134,6 +134,12 @@ export function nxNodeMetadata(
         : {}),
     },
   };
+}
+
+function readNxProjectTags(
+  project: AdapterWorkspaceSnapshot['projects'][number]
+): string[] {
+  return [...(project.nxTags ?? project.tags ?? [])];
 }
 
 export function nxRelationMetadata(

--- a/packages/governance-adapter-nx/src/types.ts
+++ b/packages/governance-adapter-nx/src/types.ts
@@ -6,6 +6,7 @@ export interface AdapterProject {
   sourceRoot?: string;
   type: string;
   tags?: string[];
+  nxTags?: string[];
   targets?: string[];
   implicitDependencies?: string[];
   metadata: Record<string, unknown>;

--- a/packages/governance/src/compatibility/host-adapter-core-flow.spec.ts
+++ b/packages/governance/src/compatibility/host-adapter-core-flow.spec.ts
@@ -58,6 +58,7 @@ describe('host -> adapter -> core compatibility flow', () => {
           root: 'libs/booking/ui',
           type: 'library',
           tags: ['scope:booking', 'layer:ui', 'type:ui'],
+          nxTags: ['scope:booking', 'layer:ui', 'type:ui'],
           targets: ['build', 'test'],
           metadata: {
             documentation: true,
@@ -68,6 +69,7 @@ describe('host -> adapter -> core compatibility flow', () => {
           root: 'libs/booking/domain',
           type: 'library',
           tags: ['scope:booking', 'layer:domain', 'type:domain'],
+          nxTags: ['scope:booking', 'layer:domain', 'type:domain'],
           targets: ['lint'],
           metadata: {
             ownership: {
@@ -139,6 +141,12 @@ describe('host -> adapter -> core compatibility flow', () => {
     expect(bookingUiNode).toMatchObject({
       id: 'booking-ui',
       root: 'libs/booking/ui',
+      tags: ['scope:booking', 'layer:ui', 'type:ui'],
+      metadata: {
+        nx: {
+          tags: ['scope:booking', 'layer:ui', 'type:ui'],
+        },
+      },
       classification: {
         scope: 'booking',
         layer: 'ui',
@@ -147,11 +155,110 @@ describe('host -> adapter -> core compatibility flow', () => {
     expect(bookingDomainNode).toMatchObject({
       id: 'booking-domain',
       root: 'libs/booking/domain',
+      tags: ['scope:booking', 'layer:domain', 'type:domain'],
+      metadata: {
+        nx: {
+          tags: ['scope:booking', 'layer:domain', 'type:domain'],
+        },
+      },
       classification: {
         scope: 'booking',
         layer: 'domain',
       },
     });
+  });
+
+  it('filters inferred npm tags while leaving profile-defined tags canonical', () => {
+    const snapshot: AdapterWorkspaceSnapshot = {
+      root: '/workspace',
+      projects: [
+        {
+          name: 'booking-app',
+          root: 'apps/booking',
+          type: 'application',
+          tags: ['domain:booking', 'layer:application'],
+          nxTags: ['domain:booking', 'layer:application', 'npm:private'],
+          targets: [],
+          metadata: {},
+        },
+        {
+          name: 'api',
+          root: 'apps/api',
+          type: 'application',
+          tags: ['type: api'],
+          nxTags: ['type: api'],
+          targets: [],
+          metadata: {},
+        },
+      ],
+      dependencies: [],
+      codeownersByProject: {},
+    };
+
+    const adapterResult = createNxWorkspaceAdapterResult(snapshot);
+    const workspace = buildGovernanceWorkspace(adapterResult);
+    const violations = evaluateGovernancePolicies(workspace, {
+      name: 'tag-prefix-profile',
+      layers: ['application', 'domain'],
+      allowedDomainDependencies: {},
+      ownership: {
+        required: false,
+      },
+      health: {
+        statusThresholds: {
+          goodMinScore: 85,
+          warningMinScore: 70,
+        },
+      },
+      metrics: {},
+      rules: {
+        'tag-convention': {
+          enabled: true,
+          severity: 'warning',
+          options: {
+            allowedPrefixes: ['domain', 'layer'],
+          },
+        },
+      },
+    });
+
+    expect(adapterResult.nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'booking-app',
+          tags: ['domain:booking', 'layer:application'],
+          metadata: {
+            nx: expect.objectContaining({
+              tags: ['domain:booking', 'layer:application', 'npm:private'],
+            }),
+          },
+        }),
+        expect.objectContaining({
+          id: 'api',
+          tags: ['type: api'],
+          metadata: {
+            nx: expect.objectContaining({
+              tags: ['type: api'],
+            }),
+          },
+        }),
+      ])
+    );
+    expect(violations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ruleId: 'tag-convention',
+          subjectId: 'api',
+        }),
+      ])
+    );
+    expect(
+      violations.some(
+        (violation) =>
+          violation.ruleId === 'tag-convention' &&
+          violation.subjectId === 'booking-app'
+      )
+    ).toBe(false);
   });
 
   it('leaves loose owner metadata as evidence only when Community ownership is required', () => {


### PR DESCRIPTION
closes #470